### PR TITLE
Upgrade to Scala 3.9.0 and remove @experimental reflection APIs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,11 +4,7 @@ lazy val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.19")
 lazy val specs2 = Def.setting("org.specs2" %%% "specs2-core" % "4.23.0")
 
 val commonSettings = Defaults.coreDefaultSettings ++ Seq(
-  /**
-   *  Symbol.newClass is marked experimental, so we should use @experimental annotation in every test suite.
-   *  3.3.0 has a bug so we can omit this annotation
-   */
-  scalaVersion := "3.3.0",
+  scalaVersion := "3.9.0",
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 )
 
@@ -98,7 +94,7 @@ def crossScalaSettings = {
       }
     }
   Seq(
-    crossScalaVersions := Seq("2.12.21", "2.13.17", scalaVersion.value),
+    crossScalaVersions := Seq("2.12.21", "2.13.18", scalaVersion.value),
     Compile / unmanagedSourceDirectories ++= addDirsByScalaVersion("src/main").value,
     Test / unmanagedSourceDirectories ++= addDirsByScalaVersion("src/test").value,
     libraryDependencies ++= {

--- a/core/jvm/src/test/scala/com.paulbutcher.test/mock/JavaMocksTest.scala
+++ b/core/jvm/src/test/scala/com.paulbutcher.test/mock/JavaMocksTest.scala
@@ -64,7 +64,7 @@ class JavaMocksTest extends IsolatedSpec {
 
     it should "mock a Polymorhpic Java interface" in { // test for issue #24
       val m = mock[PolymorphicJavaInterface]
-      (m.simplePolymorphicMethod _).expects("foo").returning(44)
+      (m.simplePolymorphicMethod[Int] _).expects("foo").returning(44)
       assertResult(44) { m.simplePolymorphicMethod[Int]("foo") }
     }
 

--- a/core/shared/src/main/scala-3/org/scalamock/clazz/MakerUtils.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/MakerUtils.scala
@@ -3,7 +3,7 @@ package org.scalamock.clazz
 import org.scalamock.stubs.Stub
 import org.scalamock.util.Defaultable
 
-import scala.annotation.{experimental, tailrec}
+import scala.annotation.tailrec
 import scala.quoted.{Expr, Quotes, Type}
 
 private[scalamock]
@@ -80,7 +80,6 @@ class MakerUtils(using override val quotes: Quotes) extends Utils:
    * @param appliedTypes collected applied types, when method is generic
    * @return StubWithMethod
    */
-  @experimental
   def searchTermWithMethod(term: Term, argTypes: List[TypeRepr], appliedTypes: List[TypeTree] = Nil): StubWithMethod =
     term match
       case Select(apply @ Apply(term, _), "apply") if apply.tpe.isContextFunctionType =>

--- a/core/shared/src/main/scala-3/org/scalamock/clazz/MockFunctionFinder.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/MockFunctionFinder.scala
@@ -27,7 +27,6 @@ object MockFunctionFinder:
    * Given something of the structure <|o.m _|> where o is a mock object
    * and m is a method, find the corresponding MockFunction instance
    */
-  @scala.annotation.experimental
   def findMockFunction[M: Type](f: Expr[Any])(using quotes: Quotes): Expr[M] =
     val utils = MakerUtils(using quotes)
     import utils.quotes.reflect.*

--- a/core/shared/src/main/scala-3/org/scalamock/clazz/MockImpl.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/MockImpl.scala
@@ -28,7 +28,6 @@ import org.scalamock.util.Defaultable
 import scala.quoted.*
 
 
-@scala.annotation.experimental
 private[clazz] object MockImpl:
   def mock[T: Type](mockContext: Expr[MockContext])(using quotes: Quotes): Expr[T] =
     MockMaker.instance[T](MockType.Mock, mockContext, name = None)

--- a/core/shared/src/main/scala-3/org/scalamock/clazz/MockMaker.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/MockMaker.scala
@@ -25,7 +25,6 @@ import org.scalamock.context.MockContext
 import scala.quoted.*
 import scala.reflect.Selectable
 
-@scala.annotation.experimental
 private[clazz] object MockMaker:
   val MockDefaultNameValName = "mock$special$mockName"
 
@@ -39,7 +38,7 @@ private[clazz] object MockMaker:
       Symbol.newVal(classSymbol, MockDefaultNameValName, TypeRepr.of[String], Flags.EmptyFlags, Symbol.noSymbol)
 
     val classSymbol: Symbol = Symbol.newClass(
-      parent = Symbol.spliceOwner,
+      owner = Symbol.spliceOwner,
       name = "$anon",
       parents = parents.map {
         case term: Term => term.tpe

--- a/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
@@ -20,7 +20,7 @@
 
 package org.scalamock.clazz
 
-import scala.annotation.{experimental, tailrec}
+import scala.annotation.tailrec
 import scala.quoted.*
 
 private[scalamock] class Utils(using val quotes: Quotes):
@@ -41,7 +41,6 @@ private[scalamock] class Utils(using val quotes: Quotes):
   object MockableDefinitions:
     private val objectMethods = TypeRepr.of[Object].typeSymbol.methodMembers.toSet
 
-    @experimental
     def find(tpe: TypeRepr, name: String, paramTypes: List[TypeRepr], appliedTypes: List[TypeRepr]): MockableDefinition =
       MockableDefinitions(tpe)
         .filter { method =>
@@ -149,7 +148,6 @@ private[scalamock] class Utils(using val quotes: Quotes):
     val tpe = ownerTpe.memberType(symbol)
     val (rawTypes, rawResType) = tpe.widen.collectTypes
 
-    @experimental
     def prepareResType(classSymbol: Symbol, methodArgs: List[List[Tree]], debug: Boolean = false): TypeRepr = {
       val methodTpe = This(classSymbol).tpe.memberType(symbol)
       val resType = methodTpe.collectTypes._2 match

--- a/core/shared/src/main/scala-3/org/scalamock/stubs/StubsMacro.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/stubs/StubsMacro.scala
@@ -1,6 +1,5 @@
 package org.scalamock.stubs
 
-import scala.annotation.experimental
 import scala.quoted.{Expr, Quotes, Type}
 
 private
@@ -107,7 +106,6 @@ private
 inline def stubbed22Impl[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R](inline f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => R): StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), R] =
   ${ stubbed22Macro[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]('{ f }) }
 
-@experimental
 private
 def stubMacro[T: Type](
   collector: Expr[internal.CreatedStubs],
@@ -116,122 +114,98 @@ def stubMacro[T: Type](
   new internal.StubMaker().newInstance[T](collector, stubUniqueIndexGenerator)
 
 
-@experimental
 private
 def stubbed00Macro[R: Type](f: Expr[R])(using Quotes): Expr[StubbedMethod[Unit, R]] =
   new internal.StubMaker().getStubbed00[R](f)
 
-@experimental
 private
 def stubbed0Macro[R: Type](f: Expr[() => R])(using Quotes): Expr[StubbedMethod[Unit, R]] =
   new internal.StubMaker().getStubbed0[R](f)
 
-@experimental
 private
 def stubbed1Macro[T1: Type, R: Type](f: Expr[T1 => R])(using Quotes): Expr[StubbedMethod[T1, R]] =
   new internal.StubMaker().getStubbed1[T1, R](f)
 
-@experimental
 private
 def stubbed2Macro[T1: Type, T2: Type, R: Type](f: Expr[(T1, T2) => R])(using Quotes): Expr[StubbedMethod[(T1, T2), R]] =
   new internal.StubMaker().getStubbed[(T1, T2), R](f)
 
-@experimental
 private
 def stubbed3Macro[T1: Type, T2: Type, T3: Type, R: Type](f: Expr[(T1, T2, T3) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3), R](f)
 
-@experimental
 private
 def stubbed4Macro[T1: Type, T2: Type, T3: Type, T4: Type, R: Type](f: Expr[(T1, T2, T3, T4) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4), R](f)
 
-@experimental
 private
 def stubbed5Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5), R](f)
 
-@experimental
 private
 def stubbed6Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6), R](f)
 
-@experimental
 private
 def stubbed7Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7), R](f)
 
-@experimental
 private
 def stubbed8Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8), R](f)
 
-@experimental
 private
 def stubbed9Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9), R](f)
 
-@experimental
 private
 def stubbed10Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, T10: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), R](f)
 
-@experimental
 private
 def stubbed11Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, T10: Type, T11: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), R](f)
 
-@experimental
 private
 def stubbed12Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, T10: Type, T11: Type, T12: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), R](f)
 
-@experimental
 private
 def stubbed13Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, T10: Type, T11: Type, T12: Type, T13: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), R](f)
 
-@experimental
 private
 def stubbed14Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, T10: Type, T11: Type, T12: Type, T13: Type, T14: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), R](f)
 
-@experimental
 private
 def stubbed15Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, T10: Type, T11: Type, T12: Type, T13: Type, T14: Type, T15: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), R](f)
 
-@experimental
 private
 def stubbed16Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, T10: Type, T11: Type, T12: Type, T13: Type, T14: Type, T15: Type, T16: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), R](f)
 
-@experimental
 private
 def stubbed17Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, T10: Type, T11: Type, T12: Type, T13: Type, T14: Type, T15: Type, T16: Type, T17: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), R](f)
 
-@experimental
 private
 def stubbed18Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, T10: Type, T11: Type, T12: Type, T13: Type, T14: Type, T15: Type, T16: Type, T17: Type, T18: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), R](f)
 
-@experimental
 private
 def stubbed19Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, T10: Type, T11: Type, T12: Type, T13: Type, T14: Type, T15: Type, T16: Type, T17: Type, T18: Type, T19: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), R](f)
 
-@experimental
 private
 def stubbed20Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, T10: Type, T11: Type, T12: Type, T13: Type, T14: Type, T15: Type, T16: Type, T17: Type, T18: Type, T19: Type, T20: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), R](f)
 
-@experimental
 private
 def stubbed21Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, T10: Type, T11: Type, T12: Type, T13: Type, T14: Type, T15: Type, T16: Type, T17: Type, T18: Type, T19: Type, T20: Type, T21: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), R](f)
 
-@experimental
 private
 def stubbed22Macro[T1: Type, T2: Type, T3: Type, T4: Type, T5: Type, T6: Type, T7: Type, T8: Type, T9: Type, T10: Type, T11: Type, T12: Type, T13: Type, T14: Type, T15: Type, T16: Type, T17: Type, T18: Type, T19: Type, T20: Type, T21: Type, T22: Type, R: Type](f: Expr[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => R])(using Quotes): Expr[StubbedMethod[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), R]] =
   new internal.StubMaker().getStubbed[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), R](f)

--- a/core/shared/src/main/scala-3/org/scalamock/stubs/internal/StubMaker.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/stubs/internal/StubMaker.scala
@@ -23,7 +23,7 @@ package org.scalamock.stubs.internal
 import org.scalamock.clazz.{MakerUtils, Utils}
 import org.scalamock.stubs.{CallLog, Stub, StubIO, StubbedMethod}
 
-import scala.annotation.{experimental, tailrec}
+import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.quoted.{Expr, Quotes, Type}
@@ -35,7 +35,6 @@ private[stubs] class StubMaker(
 
   override def newApi = true
 
-  @experimental
   def newInstance[T: Type](
     collector: Expr[CreatedStubs],
     stubUniqueIndexGenerator: Expr[StubUniqueIndexGenerator]
@@ -46,7 +45,7 @@ private[stubs] class StubMaker(
     val log = Expr.summon[CallLog]
 
     val classSymbol = Symbol.newClass(
-      parent = Symbol.spliceOwner,
+      owner = Symbol.spliceOwner,
       name = "anon",
       parents = parents.map {
         case term: Term => term.tpe
@@ -202,19 +201,15 @@ private[stubs] class StubMaker(
         (acc += tpe).toList
 
 
-  @experimental
   def getStubbed00[R: Type](select: Expr[R]): Expr[StubbedMethod[Unit, R]] =
     searchTermWithMethod(select.asTerm, Nil).selectReflect[StubbedMethod[Unit, R]](_.stubValName)
 
-  @experimental
   def getStubbed0[R: Type](select: Expr[() => R]): Expr[StubbedMethod[Unit, R]] =
     searchTermWithMethod(select.asTerm, Nil).selectReflect[StubbedMethod[Unit, R]](_.stubValName)
 
-  @experimental
   def getStubbed1[T1: Type, R: Type](select: Expr[Any]): Expr[StubbedMethod[T1, R]] =
     searchTermWithMethod(select.asTerm, List(TypeRepr.of[T1])).selectReflect[StubbedMethod[T1, R]](_.stubValName)
 
-  @experimental
   def getStubbed[Args: Type, R: Type](select: Expr[Any]): Expr[StubbedMethod[Args, R]] =
     searchTermWithMethod(select.asTerm, tupleTypeToList(TypeRepr.of[Args])).selectReflect[StubbedMethod[Args, R]](_.stubValName)
 

--- a/core/shared/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
+++ b/core/shared/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
@@ -413,7 +413,7 @@ class MockTest extends AnyFreeSpec with MockFactory with Matchers {
 
       val provider = mock[DataProviderComponent]
 
-      (provider.find[User](_: Int)(_: ClassTag[User])) expects (13, *) returning (Failure[User](new Exception()))
+      (provider.find[User](_: Int)(using _: ClassTag[User])) expects (13, *) returning (Failure[User](new Exception()))
       provider.find[User](13) shouldBe a[Failure[_]]
     }
 

--- a/core/shared/src/test/scala/org/scalamock/test/scalatest/PathSpecTest.scala
+++ b/core/shared/src/test/scala/org/scalamock/test/scalatest/PathSpecTest.scala
@@ -20,6 +20,7 @@
 
 package org.scalamock.test.scalatest
 
+import org.scalamock.function.MockFunction1
 import org.scalamock.scalatest.PathMockFactory
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.funspec
@@ -51,7 +52,7 @@ class PathSpecTest extends funspec.PathAnyFunSpec with Matchers with PathMockFac
     }
   
     it("can have expectations checked at the end of root suite") {
-      val mockFun = mockFunction[String, Unit]("mockFun")
+      val mockFun: MockFunction1[String, Unit] = mockFunction[String, Unit]("mockFun")
       mockFun expects "bottom-level"
       val caught = intercept[TestFailedException] {
         verifyExpectations()

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,5 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.20.2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")

--- a/zio/shared/src/main/scala-3/org/scalamock/clazz/ziotest/macros/CheckEffectInvocationMacros.scala
+++ b/zio/shared/src/main/scala-3/org/scalamock/clazz/ziotest/macros/CheckEffectInvocationMacros.scala
@@ -24,7 +24,6 @@ package org.scalamock.clazz.ziotest.macros
 import org.scalamock.clazz.{MockMaker, MockType}
 import org.scalamock.context.MockContext
 
-import scala.annotation.experimental
 import scala.quoted.*
 
 import zio.ZIO
@@ -80,7 +79,6 @@ import zio.ZIO
  * So when the method is called, it's not added to callLog immediately.
  * It's added only when the effect f(x) is actually called.
  */
-@experimental
 private[scalamock] object CheckEffectInvocationMacros {
 
   def mock[T: Type](mockContext: Expr[MockContext])(using Quotes): Expr[T] = {


### PR DESCRIPTION
- Bump Scala 3 version to 3.9.0 in build.sbt
- Remove @experimental annotations and migrate to stable Quotes Reflect APIs (Symbol.newClass now uses the owner parameter instead of the removed parent parameter)
- Fix Scala 3.9.0 overload-resolution regression in PathSpecTest by explicitly typing mockFunction as MockFunction1
- Fix Scala 3.9.0 polymorphic eta-expansion regression in JavaMocksTest by explicitly applying the type parameter to simplePolymorphicMethod before eta-expansion
- Upgrade sbt-scalajs plugin to 1.22.0 to support the Scala.js IR version produced by the Scala 3.9.0 compiler
