### PR TITLE
Fix #734: handle FlexibleType in Utils.scala for -Yexplicit-nulls suppport

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,6 +109,8 @@ def crossScalaSettings = {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, _)) =>
           Seq("-Xlint:adapted-args", "-Xfatal-warnings")
+        case Some((3, _)) =>
+          Seq("-Yexplicit-nulls", "-language:unsafeNulls")
         case _ =>
           Seq.empty
       }

--- a/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
@@ -92,6 +92,9 @@ private[scalamock] class Utils(using val quotes: Quotes):
           case OrType(left, right) =>
             OrType(updateParamRefs(left, methodTpe), updateParamRefs(right, methodTpe))
 
+          case FlexibleType(other) =>
+            FlexibleType(updateParamRefs(other, methodTpe))
+
           case _ =>
             tpe
         }
@@ -172,6 +175,9 @@ private[scalamock] class Utils(using val quotes: Quotes):
 
               case AnnotatedType(other, annot) =>
                 AnnotatedType(loop(other), annot)
+
+              case FlexibleType(other) =>
+                FlexibleType(loop(other))
 
               case ff@TypeRef(ref@ParamRef(bindings, idx), name) =>
                 def getIndex(bindings: TypeRepr): Int =


### PR DESCRIPTION
fixes #734 

Add FlexibleType cases to updateParamRefs and prepareResType loops so that mocking polymorphic Java interfaces works under -Yexplicit-nulls -language:unsafeNulls. Also enable these flags for Scala 3 test builds to cover this scenario in CI.

