### PR TITLE
Batch dependency update + fix CI Scala version matrix

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -20,8 +20,8 @@ jobs:
         distribution: 'adopt'
     - uses: sbt/setup-sbt@v1
     - name: Run tests
-      run: sbt ++2.12.20 test
-      
+      run: sbt ++2.12.21 test
+
   scala_2_13:
 
     runs-on: ubuntu-latest
@@ -35,7 +35,7 @@ jobs:
         distribution: 'adopt'
     - uses: sbt/setup-sbt@v1
     - name: Run tests
-      run: sbt ++2.13.15 test
+      run: sbt ++2.13.18 test
 
   scala_3:
 
@@ -50,4 +50,4 @@ jobs:
           distribution: 'adopt'
       - uses: sbt/setup-sbt@v1
       - name: Run tests
-        run: sbt ++3.3.0 test
+        run: sbt ++3.9.0 test

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'adopt'
       - uses: sbt/setup-sbt@v1
       - name: Run tests

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
-lazy val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.19")
+lazy val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.20")
 lazy val specs2 = Def.setting("org.specs2" %%% "specs2-core" % "4.23.0")
 
 val commonSettings = Defaults.coreDefaultSettings ++ Seq(
@@ -42,7 +42,7 @@ lazy val `scalamock-zio` = crossProject(JSPlatform, JVMPlatform)
     commonSettings,
     crossScalaSettings,
     libraryDependencies ++= {
-      val zioVersion = "2.1.22"
+      val zioVersion = "2.1.26"
       Seq(
         "dev.zio" %%% "zio" % zioVersion,
         "dev.zio" %%% "zio-test" % zioVersion,
@@ -63,7 +63,7 @@ lazy val `scalamock-cats-effect` = crossProject(JSPlatform, JVMPlatform)
     crossScalaSettings,
     libraryDependencies ++= Seq(
 
-      "org.typelevel" %% "cats-effect" % "3.6.4",
+      "org.typelevel" %% "cats-effect" % "3.7.0",
       "org.typelevel" %% "munit-cats-effect" % "2.2.0" % Test
     )
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.4
+sbt.version=1.13.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.2")
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.4.0")


### PR DESCRIPTION
Consolidates several pending scala-steward dependency PRs into one, plus fixes a CI Scala version matrix mismatch that started failing after the Scala 3.9.0 bump.

## Dependency bumps
- sbt 1.12.4 -> **1.13.0** (includes fix for GHSA-943m-f264-54p4; newer than the 1.12.15 in #744)
- sbt-ci-release 1.11.1 -> **1.12.1** (newer than the 1.11.2 in #671)
- sbt-scalajs-crossproject 1.3.2 -> 1.4.0 (#745)
- scalatest 3.2.19 -> 3.2.20 (#730)
- zio/zio-test/zio-test-sbt 2.1.22 -> 2.1.26 (#737)
- cats-effect 3.6.4 -> 3.7.0 (#726)

sbt-scalajs (1.22.0, #741) and scala-library/scala-reflect (2.13.18, #707) were already up to date on `series/7.x`.

## CI fix
`.github/workflows/scala.yml` still referenced `2.12.20` / `2.13.15` / `3.3.0`, which no longer match `build.sbt`'s `crossScalaVersions` (`2.12.21`, `2.13.18`, `3.9.0`). This caused CI failures like:
```
[error] Switch failed: no subprojects list "3.3.0" (or compatible version) in crossScalaVersions setting.
```
Updated the matrix to `2.12.21` / `2.13.18` / `3.9.0`.

## Verification (local)
- Scala 3.9.0 JVM: 474 tests passed
- Scala 2.13.18 / 2.12.21 JVM: 433 tests passed
- zio module (JVM): 46 tests passed
- cats-effect module (JVM): 19 tests passed
- JS compilation (core, zio, cats-effect): success
- sbt reloads cleanly on 1.13.0 with updated plugins

After merge, the following redundant scala-steward PRs should be closed: #726, #730, #737, #741, #744, #745, #671, #707.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author