### PR TITLE
Add returnsWhen stubbing method

### DIFF
--- a/cats-effect/shared/src/main/scala/org/scalamock/stubs/StubbedIOMethod.scala
+++ b/cats-effect/shared/src/main/scala/org/scalamock/stubs/StubbedIOMethod.scala
@@ -198,6 +198,8 @@ class StubbedIOMethod[A, R](delegate: StubbedMethod[A, R]) extends StubbedMethod
    * */
   def returnsWith(f: => R): Unit = delegate.returnsWith(f)
 
+  def returnsWhen(pf: PartialFunction[A, R]): Unit = delegate.returnsWhen(pf)
+
   /** Allows to set result depending on call number starting from 1
    *
    * Scala 3

--- a/core/shared/src/main/scala/org/scalamock/stubs/StubNotImplementedError.scala
+++ b/core/shared/src/main/scala/org/scalamock/stubs/StubNotImplementedError.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2011-2025 ScalaMock Contributors (https://github.com/ScalaMock/ScalaMock/graphs/contributors)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package org.scalamock.stubs
+
+final class StubNotImplementedError private(msg: String)
+  extends Error(msg)
+
+object StubNotImplementedError {
+  private[stubs] def apply(method: StubbedMethod[_, _]) =
+    new StubNotImplementedError(s"Implementation is missing for [$method]")
+
+  private[stubs] def apply(method: StubbedMethod[_, _], arg: Any) =
+    new StubNotImplementedError(s"Implementation is missing for [$method]\nand argument [$arg]")
+}

--- a/core/shared/src/main/scala/org/scalamock/stubs/StubbedMethod.scala
+++ b/core/shared/src/main/scala/org/scalamock/stubs/StubbedMethod.scala
@@ -83,6 +83,31 @@ trait StubbedMethod[A, R] {
    * */
   def returnsWith(value: => R): Unit
 
+  /** Allows to set a result for the method with arguments using a partial function
+   * in order to stub a certain set of argument values only and fail otherwise.
+   *
+   * Scala 3
+   * {{{
+   *   foo.foo.returnsWhen:
+   *     case 1 => 100
+   * }}}
+   * Scala 2
+   * {{{
+   *   (foo.foo _).returnsWhen {
+   *     case 1 => 100
+   *   }
+   * }}}
+   * If the stubbed method is called with an argument for which the partial function is not defined,
+   * then a `StubNotImplementedException` will be thrown:
+   * {{{
+   *   foo.foo(1) // returns 100
+   *   foo.foo(3) // throws StubNotImplementedException
+   * }}}
+   *
+   * @param pf partial function from arguments of type `A` to result of type `R`
+   */
+  def returnsWhen(pf: PartialFunction[A, R]): Unit
+
   /** Allows to set result depending on call number starting from 1
    *
    * Scala 3
@@ -231,18 +256,20 @@ object StubbedMethod {
     private val callsRef: AtomicReference[List[A]] =
       new AtomicReference[List[A]](Nil)
 
-    private val resultRef: AtomicReference[Option[A => R]] =
-      new AtomicReference[Option[A => R]](None)
+    private val resultRef: AtomicReference[PartialFunction[A, R]] =
+      new AtomicReference[PartialFunction[A, R]](PartialFunction.empty)
 
     def impl(args: A): R =
       io match {
         case None =>
           callLog.foreach(_.internal.write(asString))
           callsRef.updateAndGet(args :: _)
-          resultRef.get() match {
-            case Some(f) => f(args)
-            case None => throw new NotImplementedError(s"Implementation is missing for [$asString]")
-          }
+          resultRef.get()
+            .applyOrElse(
+              args,
+              (_: A) => throw StubNotImplementedError(this, args)
+            )
+
         case Some(io) =>
           io.flatMap(
             io.succeed {
@@ -250,26 +277,30 @@ object StubbedMethod {
               callsRef.updateAndGet(args :: _)
             }
           ) { _ =>
-            resultRef.get() match {
-              case Some(f) => f(args).asInstanceOf[io.F[Any, Any]]
-              case None => io.die(new NotImplementedError(s"Implementation is missing for [$asString]"))
-            }
+            resultRef.get()
+              .asInstanceOf[PartialFunction[A, io.F[Any, Any]]]
+              .applyOrElse(
+                args,
+                (_: A) => io.die(StubNotImplementedError(this, args)))
           }.asInstanceOf[R]
       }
 
     def clear(): Unit = {
       callsRef.set(Nil)
-      resultRef.set(None)
+      resultRef.set(PartialFunction.empty)
     }
 
     override def returns(f: A => R): Unit =
-      resultRef.set(Some(f))
+      resultRef.set { case a => f(a) }
 
     override def returnsWith(value: => R): Unit =
-      resultRef.set(Some(_ => value))
+      resultRef.set { case _ => value }
+
+    override def returnsWhen(pf: PartialFunction[A, R]): Unit =
+      resultRef.set(pf)
 
     override def returnsOnCall(f: Int => R): Unit =
-      resultRef.set(Some(_ => f(callsRef.get().length)))
+      resultRef.set { case _ => f(callsRef.get().length) }
 
     override def times: Int =
       callsRef.get().length

--- a/core/shared/src/test/scala-2/newapi/NewApiSpec.scala
+++ b/core/shared/src/test/scala-2/newapi/NewApiSpec.scala
@@ -1,7 +1,7 @@
 package newapi
 
 import com.paulbutcher.test._
-import org.scalamock.stubs.Stubs
+import org.scalamock.stubs.{Stubs, StubNotImplementedError}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import some.other.pkg.SomeOtherClass
@@ -1093,6 +1093,15 @@ class NewApiSpec extends AnyFunSpec with Matchers with Stubs {
     m.withOneDefaultParam("a") shouldBe "one"
     m.withOneDefaultParam("a", "default") shouldBe "one"
     m.withOneDefaultParam("a", "other") shouldBe "two"
+
+    intercept[StubNotImplementedError] {
+      m.withTwoDefaultParams("x", "y") // not stubbed
+    }.getMessage should {
+      // Exact error message varies in Scala 2.12 and 2.13
+      startWith("Implementation is missing for [") and
+        include("ClassHavingMethodsWithDefaultParams.withTwoDefaultParams(a: String, b: String, c: Int)") and
+        endWith("]\nand argument [(x,y,42)]")
+    }
   }
 
   it("stub class methods with two default parameters") {
@@ -1108,6 +1117,15 @@ class NewApiSpec extends AnyFunSpec with Matchers with Stubs {
     m.withTwoDefaultParams("a", "default") shouldBe "one"
     m.withTwoDefaultParams("a", "default", 42) shouldBe "one"
     m.withTwoDefaultParams("a", "other", 99) shouldBe "two"
+
+    intercept[StubNotImplementedError] {
+      m.withOneDefaultParam("x") // not stubbed
+    }.getMessage should {
+      // Exact error message varies in Scala 2.12 and 2.13
+      startWith("Implementation is missing for [") and
+        include("ClassHavingMethodsWithDefaultParams.withOneDefaultParam(a: String, b: String)") and
+        endWith("]\nand argument [(x,default)]")
+    }
   }
 
   it("stub trait methods with type param and default parameters") {
@@ -1120,6 +1138,72 @@ class NewApiSpec extends AnyFunSpec with Matchers with Stubs {
 
     m.withDefaultParamAndTypeParam[Int]("default", 5) shouldBe 5
     m.withDefaultParamAndTypeParam[Int]("defaul", 5) shouldBe 6
+
+    intercept[StubNotImplementedError] {
+      m.withAllDefaultParams() // not stubbed
+    }.getMessage should {
+      // Exact error message varies in Scala 2.12 and 2.13
+      startWith("Implementation is missing for [") and
+        include("TraitHavingMethodsWithDefaultParams.withAllDefaultParams(a: String, b: NewApiSpec.this.CaseClass)") and
+        endWith("]\nand argument [(default,CaseClass(42))]")
+    }
+  }
+
+  it("returnsWhen cope with 1-param method") {
+    val m = stub[TestTrait]
+    (m.oneParam _).returnsWhen {
+      case 42 => "the answer to everything"
+    }
+
+    m.oneParam(42) shouldBe "the answer to everything"
+
+    intercept[StubNotImplementedError] {
+      m.oneParam(100)
+    }.getMessage should {
+      // Exact error message varies in Scala 2.12 and 2.13
+      startWith("Implementation is missing for [") and
+        include("TestTrait.oneParam(x: Int)") and
+        endWith("]\nand argument [100]")
+    }
+  }
+
+  it("returnsWhen cope with 2-param method") {
+    val m = stub[TestTrait]
+    (m.twoParams _).returnsWhen {
+      case (1, 2.3) => "nice"
+      case (4, _) => "cool"
+    }
+
+    m.twoParams(1, 2.3) shouldBe "nice"
+    m.twoParams(4, 5.6) shouldBe "cool"
+
+    intercept[StubNotImplementedError] {
+      m.twoParams(1, 1.1)
+    }.getMessage should {
+      // Exact error message varies in Scala 2.12 and 2.13
+      // Also note that Double can be formatted differently on JVM and JS.
+      startWith("Implementation is missing for [") and
+        include("TestTrait.twoParams(x: Int, y: Double)") and
+        endWith("]\nand argument [(1,1.1)]")
+    }
+  }
+
+  it("returnsWhen cope with curried method") {
+    val m = stub[TestTrait]
+    (m.curried(_: Int)(_: Double)).returnsWhen {
+      case (123, 45.6) => "789"
+    }
+    m.curried(123)(45.6) shouldBe "789"
+
+    intercept[StubNotImplementedError] {
+      m.curried(654)(3.21)
+    }.getMessage should {
+      // Exact error message varies in Scala 2.12 and 2.13
+      // Also note that Double can be formatted differently on JVM and JS.
+      startWith("Implementation is missing for [") and
+        include("TestTrait.curried(x: Int)(y: Double)") and
+        endWith("]\nand argument [(654,3.21)]")
+    }
   }
 
   it("should mock generic Iterable") {

--- a/core/shared/src/test/scala-3/newapi/NewApiSpec.scala
+++ b/core/shared/src/test/scala-3/newapi/NewApiSpec.scala
@@ -1,7 +1,7 @@
 package newapi
 
 import com.paulbutcher.test.{PolymorphicTrait, SpecializedClass, SpecializedClass2, TestClass, TestTrait}
-import org.scalamock.stubs.Stubs
+import org.scalamock.stubs.{Stubs, StubNotImplementedError}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import some.other.pkg.SomeOtherClass
@@ -1232,9 +1232,14 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
     m.withOneDefaultParam("a") shouldBe "one"
     m.withOneDefaultParam("a", "default") shouldBe "one"
     m.withOneDefaultParam("a", "other") shouldBe "two"
+
+    the[StubNotImplementedError] thrownBy {
+      m.withTwoDefaultParams("x", "y") // not stubbed
+    } should have message
+      "Implementation is missing for [<stub-101> ClassHavingMethodsWithDefaultParams.withTwoDefaultParams(a: String, b: String, c: Int)String]\nand argument [(x,y,42)]"
   }
 
-  it("stub class methods with two default parameters"):
+  it("stub class methods with two default parameters") {
     val m = stub[ClassHavingMethodsWithDefaultParams]
 
     m.withTwoDefaultParams.returns:
@@ -1247,6 +1252,12 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
     m.withTwoDefaultParams("a", "default", 42) shouldBe "one"
     m.withTwoDefaultParams("a", "other", 99) shouldBe "two"
 
+    the[StubNotImplementedError] thrownBy {
+      m.withOneDefaultParam("x") // not stubbed
+    } should have message
+      "Implementation is missing for [<stub-102> ClassHavingMethodsWithDefaultParams.withOneDefaultParam(a: String, b: String)String]\nand argument [(x,default)]"
+  }
+
   it("stub trait methods with type param and default parameters") {
     val m = stub[TraitHavingMethodsWithDefaultParams]
 
@@ -1256,5 +1267,48 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
 
     m.withDefaultParamAndTypeParam[Int]("default", 5) shouldBe 5
     m.withDefaultParamAndTypeParam[Int]("defaul", 5) shouldBe 6
+
+    the[StubNotImplementedError] thrownBy {
+      m.withAllDefaultParams() // not stubbed
+    } should have message
+      "Implementation is missing for [<stub-103> TraitHavingMethodsWithDefaultParams.withAllDefaultParams(a: String, b: CaseClass)String]\nand argument [(default,CaseClass(42))]"
+  }
+
+  it("returnsWhen cope with 1-param method") {
+    val m = stub[TestTrait]
+    m.oneParam.returnsWhen:
+      case 42 => "the answer to everything"
+
+    m.oneParam(42) shouldBe "the answer to everything"
+    the[StubNotImplementedError] thrownBy {
+      m.oneParam(100)
+    } should have message
+      "Implementation is missing for [<stub-104> TestTrait.oneParam(x: Int)String]\nand argument [100]"
+  }
+
+  it("returnsWhen cope with 2-param method") {
+    val m = stub[TestTrait]
+    m.twoParams.returnsWhen:
+      case (1, 2.3) => "nice"
+      case (4, _) => "cool"
+
+    m.twoParams(1, 2.3) shouldBe "nice"
+    m.twoParams(4, 5.6) shouldBe "cool"
+    the[StubNotImplementedError] thrownBy {
+      m.twoParams(1, 1.1)
+    } should have message
+      "Implementation is missing for [<stub-105> TestTrait.twoParams(x: Int, y: Double)String]\nand argument [(1,1.1)]"
+  }
+
+  it("returnsWhen cope with curried method") {
+    val m = stub[TestTrait]
+    (m.curried(_: Int)(_: Double)).returnsWhen:
+      case (123, 45.6) => "789"
+
+    m.curried(123)(45.6) shouldBe "789"
+    the[StubNotImplementedError] thrownBy {
+      m.curried(654)(3.21)
+    } should have message
+      "Implementation is missing for [<stub-106> TestTrait.curried(x: Int)(y: Double)String]\nand argument [(654,3.21)]"
   }
 

--- a/zio/shared/src/main/scala/org/scalamock/stubs/StubbedZIOMethod.scala
+++ b/zio/shared/src/main/scala/org/scalamock/stubs/StubbedZIOMethod.scala
@@ -221,6 +221,8 @@ class StubbedZIOMethod[A, R](delegate: StubbedMethod[A, R]) extends StubbedMetho
    * */
   def returnsWith(value: => R) = delegate.returnsWith(value)
 
+  def returnsWhen(pf: PartialFunction[A, R]): Unit = delegate.returnsWhen(pf)
+
   /** Allows to set result depending on call number starting from 1
    *
    * Scala 3


### PR DESCRIPTION
Adds a returnsWhen(pf: PartialFunction[A, R]) method to StubbedMethod (and its Cats Effect / ZIO counterparts) allowing a stub to be defined for a subset of argument values only. Calling the stub with an argument for which the partial function is not defined throws a new StubNotImplementedError describing the failing method and argument.

# Pull Request Checklist

* [ ] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [ ] I have added copyright headers to new files
* [ ] I have added tests for any changed functionality

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
