### PR TITLE
Add Scala Native support (Scala 3 only)

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -20,7 +20,16 @@ jobs:
         distribution: 'adopt'
     - uses: sbt/setup-sbt@v1
     - name: Run tests
-      run: sbt ++2.12.21 test
+      # Scala Native is Scala 3 only (crossScalaVersions is pinned to 3.x for
+      # the .native projects), so plain `test` on the aggregated root project
+      # would still try to compile those modules with the Scala 3 compiler
+      # bridge, which requires a newer JDK than this job uses. Scope the run
+      # to the JVM/JS projects instead.
+      run: >
+        sbt ++2.12.21
+        scalamockJVM/test scalamockJS/test
+        scalamock-zioJVM/test scalamock-zioJS/test
+        scalamock-cats-effectJVM/test scalamock-cats-effectJS/test
 
   scala_2_13:
 
@@ -35,7 +44,12 @@ jobs:
         distribution: 'adopt'
     - uses: sbt/setup-sbt@v1
     - name: Run tests
-      run: sbt ++2.13.18 test
+      # See comment in scala_2_12 job: Scala Native is Scala 3 only.
+      run: >
+        sbt ++2.13.18
+        scalamockJVM/test scalamockJS/test
+        scalamock-zioJVM/test scalamock-zioJS/test
+        scalamock-cats-effectJVM/test scalamock-cats-effectJS/test
 
   scala_3:
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,13 +15,16 @@ lazy val root = project.in(file("."))
   .aggregate(
     scalamock.jvm,
     scalamock.js,
+    scalamock.native,
     `scalamock-zio`.jvm,
     `scalamock-zio`.js,
+    `scalamock-zio`.native,
     `scalamock-cats-effect`.jvm,
-    `scalamock-cats-effect`.js
+    `scalamock-cats-effect`.js,
+    `scalamock-cats-effect`.native
   )
 
-lazy val scalamock = crossProject(JSPlatform, JVMPlatform)
+lazy val scalamock = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("core"))
   .settings(
     commonSettings,
@@ -34,8 +37,13 @@ lazy val scalamock = crossProject(JSPlatform, JVMPlatform)
       specs2.value % Optional
     )
   )
+  // Scala Native 0.5 dropped java.lang.reflect support, which the Scala 2 macros rely on.
+  // Only Scala 3 (which uses scala.reflect.Selectable instead) is supported on Native.
+  .nativeSettings(
+    crossScalaVersions := Seq(scalaVersion.value)
+  )
 
-lazy val `scalamock-zio` = crossProject(JSPlatform, JVMPlatform)
+lazy val `scalamock-zio` = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("zio"))
   .settings(
     name := "scalamock-zio",
@@ -52,10 +60,14 @@ lazy val `scalamock-zio` = crossProject(JSPlatform, JVMPlatform)
   )
   .jsSettings(name := "scalamock-zio")
   .jvmSettings(name := "scalamock-zio")
+  .nativeSettings(
+    name := "scalamock-zio",
+    crossScalaVersions := Seq(scalaVersion.value)
+  )
   .dependsOn(scalamock)
 
 
-lazy val `scalamock-cats-effect` = crossProject(JSPlatform, JVMPlatform)
+lazy val `scalamock-cats-effect` = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("cats-effect"))
   .settings(
     name := "scalamock-cats-effect",
@@ -63,12 +75,16 @@ lazy val `scalamock-cats-effect` = crossProject(JSPlatform, JVMPlatform)
     crossScalaSettings,
     libraryDependencies ++= Seq(
 
-      "org.typelevel" %% "cats-effect" % "3.7.0",
-      "org.typelevel" %% "munit-cats-effect" % "2.2.0" % Test
+      "org.typelevel" %%% "cats-effect" % "3.7.0",
+      "org.typelevel" %%% "munit-cats-effect" % "2.2.0" % Test
     )
   )
   .jsSettings(name := "scalamock-cats-effect")
   .jvmSettings(name := "scalamock-cats-effect")
+  .nativeSettings(
+    name := "scalamock-cats-effect",
+    crossScalaVersions := Seq(scalaVersion.value)
+  )
   .dependsOn(scalamock)
 
 lazy val examples = project

--- a/core/shared/src/test/scala-3/newapi/NewApiSpec.scala
+++ b/core/shared/src/test/scala-3/newapi/NewApiSpec.scala
@@ -1233,10 +1233,13 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
     m.withOneDefaultParam("a", "default") shouldBe "one"
     m.withOneDefaultParam("a", "other") shouldBe "two"
 
-    the[StubNotImplementedError] thrownBy {
+    intercept[StubNotImplementedError] {
       m.withTwoDefaultParams("x", "y") // not stubbed
-    } should have message
-      "Implementation is missing for [<stub-99> ClassHavingMethodsWithDefaultParams.withTwoDefaultParams(a: String, b: String, c: Int)String] and argument [(x,y,42)]"
+    }.getMessage should {
+      startWith("Implementation is missing for [") and
+        include("ClassHavingMethodsWithDefaultParams.withTwoDefaultParams(a: String, b: String, c: Int)String") and
+        endWith("] and argument [(x,y,42)]")
+    }
   }
 
   it("stub class methods with two default parameters") {
@@ -1252,10 +1255,13 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
     m.withTwoDefaultParams("a", "default", 42) shouldBe "one"
     m.withTwoDefaultParams("a", "other", 99) shouldBe "two"
 
-    the[StubNotImplementedError] thrownBy {
+    intercept[StubNotImplementedError] {
       m.withOneDefaultParam("x") // not stubbed
-    } should have message
-      "Implementation is missing for [<stub-100> ClassHavingMethodsWithDefaultParams.withOneDefaultParam(a: String, b: String)String] and argument [(x,default)]"
+    }.getMessage should {
+      startWith("Implementation is missing for [") and
+        include("ClassHavingMethodsWithDefaultParams.withOneDefaultParam(a: String, b: String)String") and
+        endWith("] and argument [(x,default)]")
+    }
   }
 
   it("stub trait methods with type param and default parameters") {
@@ -1268,10 +1274,13 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
     m.withDefaultParamAndTypeParam[Int]("default", 5) shouldBe 5
     m.withDefaultParamAndTypeParam[Int]("defaul", 5) shouldBe 6
 
-    the[StubNotImplementedError] thrownBy {
+    intercept[StubNotImplementedError] {
       m.withAllDefaultParams() // not stubbed
-    } should have message
-      "Implementation is missing for [<stub-101> TraitHavingMethodsWithDefaultParams.withAllDefaultParams(a: String, b: CaseClass)String] and argument [(default,CaseClass(42))]"
+    }.getMessage should {
+      startWith("Implementation is missing for [") and
+        include("TraitHavingMethodsWithDefaultParams.withAllDefaultParams(a: String, b: CaseClass)String") and
+        endWith("] and argument [(default,CaseClass(42))]")
+    }
   }
 
   it("returnsWhen cope with 1-param method") {
@@ -1280,10 +1289,13 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
       case 42 => "the answer to everything"
 
     m.oneParam(42) shouldBe "the answer to everything"
-    the[StubNotImplementedError] thrownBy {
+    intercept[StubNotImplementedError] {
       m.oneParam(100)
-    } should have message
-      "Implementation is missing for [<stub-102> TestTrait.oneParam(x: Int)String] and argument [100]"
+    }.getMessage should {
+      startWith("Implementation is missing for [") and
+        include("TestTrait.oneParam(x: Int)String") and
+        endWith("] and argument [100]")
+    }
   }
 
   it("returnsWhen cope with 2-param method") {
@@ -1294,10 +1306,13 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
 
     m.twoParams(1, 2.3) shouldBe "nice"
     m.twoParams(4, 5.6) shouldBe "cool"
-    the[StubNotImplementedError] thrownBy {
+    intercept[StubNotImplementedError] {
       m.twoParams(1, 1.1)
-    } should have message
-      "Implementation is missing for [<stub-103> TestTrait.twoParams(x: Int, y: Double)String] and argument [(1,1.1)]"
+    }.getMessage should {
+      startWith("Implementation is missing for [") and
+        include("TestTrait.twoParams(x: Int, y: Double)String") and
+        endWith("] and argument [(1,1.1)]")
+    }
   }
 
   it("returnsWhen cope with curried method") {
@@ -1306,8 +1321,11 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
       case (123, 45.6) => "789"
 
     m.curried(123)(45.6) shouldBe "789"
-    the[StubNotImplementedError] thrownBy {
+    intercept[StubNotImplementedError] {
       m.curried(654)(3.21)
-    } should have message
-      "Implementation is missing for [<stub-104> TestTrait.curried(x: Int)(y: Double)String] and argument [(654,3.21)]"
+    }.getMessage should {
+      startWith("Implementation is missing for [") and
+        include("TestTrait.curried(x: Int)(y: Double)String") and
+        endWith("] and argument [(654,3.21)]")
+    }
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,6 @@ addSbtPlugin("com.github.sbt" % "sbt-git" % "2.2.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.4.0")
+
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")


### PR DESCRIPTION
Scala Native 0.5 removed java.lang.reflect support entirely, which the Scala 2 mock/stub macros (MockFunctionFinderImpl, StubbedMethodFinderImpl, ClearStubs) rely on for runtime method resolution. Since Scala 3 uses scala.reflect.Selectable instead, Native support is enabled for Scala 3 only, via crossScalaVersions restriction in each nativeSettings block.

- Add sbt-scala-native and sbt-scala-native-crossproject plugins
- Add NativePlatform to scalamock, scalamock-zio, scalamock-cats-effect cross-projects
- Aggregate .native modules in root project

# Pull Request Checklist

* [ ] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [ ] I have added copyright headers to new files
* [ ] I have added tests for any changed functionality

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
