### PR TITLE
Add specs2-5 support module (Scala 3 only)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 lazy val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.20")
 lazy val specs2 = Def.setting("org.specs2" %%% "specs2-core" % "4.23.0")
+lazy val specs2_5 = Def.setting("org.specs2" %%% "specs2-core" % "5.9.1")
 
 val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   scalaVersion := "3.9.0",
@@ -24,7 +25,10 @@ lazy val root = project.in(file("."))
     `scalamock-cats-effect`.native,
     `scalamock-specs2-4`.jvm,
     `scalamock-specs2-4`.js,
-    `scalamock-specs2-4`.native
+    `scalamock-specs2-4`.native,
+    `scalamock-specs2-5`.jvm,
+    `scalamock-specs2-5`.js,
+    `scalamock-specs2-5`.native
   )
 
 lazy val scalamock = crossProject(JSPlatform, JVMPlatform, NativePlatform)
@@ -101,6 +105,19 @@ lazy val `scalamock-specs2-4` = crossProject(JSPlatform, JVMPlatform, NativePlat
   // Only Scala 3 (which uses scala.reflect.Selectable instead) is supported on Native.
   .nativeSettings(
     crossScalaVersions := Seq(scalaVersion.value)
+  )
+  .dependsOn(scalamock)
+
+// specs2 5.x dropped Scala 2 support entirely - only Scala 3 artifacts are published
+// (for JVM, JS and Native), so this module is restricted to Scala 3 across all platforms.
+lazy val `scalamock-specs2-5` = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .in(file("specs2/specs2-5"))
+  .settings(
+    name := "scalamock-specs2-5",
+    commonSettings,
+    crossScalaSettings,
+    crossScalaVersions := Seq(scalaVersion.value),
+    libraryDependencies += specs2_5.value
   )
   .dependsOn(scalamock)
 

--- a/specs2/specs2-5/jvm/src/test/scala/org/scalamock/test/specs2/ConcurrencyTest.scala
+++ b/specs2/specs2-5/jvm/src/test/scala/org/scalamock/test/specs2/ConcurrencyTest.scala
@@ -1,0 +1,95 @@
+// Copyright (c) 2011-2015 ScalaMock Contributors (https://github.com/paulbutcher/ScalaMock/graphs/contributors)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package org.scalamock.test.specs2
+
+import org.scalamock.specs2.SuiteMockFactory
+import org.scalamock.test.mockable.TestTrait
+import org.specs2.mutable.Specification
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.{Duration, SECONDS}
+import scala.concurrent.{Await, Future}
+
+class ConcurrencyTest extends Specification with SuiteMockFactory {
+
+  "Futures should work" in {
+    val s = stubFunction[Int]
+    s.when().returns(1)
+    Await.result(Future { s() }, Duration(10, SECONDS)) must be_==(1)
+    s.verify().once()
+    success
+  }
+
+  "Concurrent mock access should work" in {
+    val m = mock[TestTrait]
+    (m.oneParamMethod _).expects(42).repeated(500000).returning("a")
+
+    val futures = (1 to 500000).map { _ =>
+      Future { m.oneParamMethod(42) }
+    }
+
+    futures.foreach(future => Await.result(future, Duration(10, SECONDS)))
+    success
+  }
+
+  case class MyClass(i: Int)
+
+  trait SlowTestTrait {
+    def oneParamMethod(param: MyClass): String
+    def otherMethod(): String
+  }
+
+  val m1 = stub[SlowTestTrait]
+  // This test fails flakily, so rerun it several times to confirm.
+  (1 to 10).foreach(i =>
+    s"Concurrent mock access should work ($i)" in {
+      val len = 500
+      val args = (0 to len).toList
+      (m1.otherMethod _).when().returns("ok")
+      args.foreach(i => (m1.oneParamMethod _).when(MyClass(i)).returns(i.toString))
+
+      val futures = args.map { i =>
+        Future {
+          m1.oneParamMethod(MyClass(i))
+        }
+      }
+
+      futures.foreach(future => Await.result(future, Duration(10, SECONDS)))
+      args.foreach { i =>
+        Future {
+          m1.otherMethod()
+        }
+      }
+      args.foreach { i =>
+        Future {
+          m1.oneParamMethod(MyClass(i))
+        }
+      }
+
+      eventually {
+        (1 to len).foreach { i =>
+          (m1.oneParamMethod _).verify(MyClass(i)).atLeastOnce()
+        }
+        success
+      }
+    })
+
+}

--- a/specs2/specs2-5/jvm/src/test/scala/org/scalamock/test/specs2/SuiteScopeMockParallelTest.scala
+++ b/specs2/specs2-5/jvm/src/test/scala/org/scalamock/test/specs2/SuiteScopeMockParallelTest.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2011-2015 ScalaMock Contributors (https://github.com/paulbutcher/ScalaMock/graphs/contributors)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package org.scalamock.test.specs2
+
+import org.scalamock.specs2.SuiteMockFactory
+import org.scalamock.test.mockable.TestTrait
+import org.specs2.mutable.Specification
+
+/**
+ *  Tests for mocks defined in suite scope (i.e. outside test case scope)
+ *
+ *  Tests for issue #25
+ */
+class SuiteScopeMockParallelTest extends Specification with SuiteMockFactory {
+  // please note that specs2 5.x no longer duplicates the specification instance per example,
+  // so this single mock is shared across examples; SuiteMockFactory serializes example
+  // execution to keep that safe under specs2's default parallel scheduling.
+
+  val mockWithoutExpectationsPredefined = mock[TestTrait]
+
+  "Specs2 suite" should {
+    "allow to use mock defined suite scope" in {
+      (mockWithoutExpectationsPredefined.oneParamMethod _).expects(1).returning("one")
+      (mockWithoutExpectationsPredefined.oneParamMethod _).expects(2).returning("two")
+
+      mockWithoutExpectationsPredefined.oneParamMethod(1) === "one"
+      mockWithoutExpectationsPredefined.oneParamMethod(2) === "two"
+    }
+
+    "allow to use mock defined suite scope in more than one test case" in {
+      (mockWithoutExpectationsPredefined.oneParamMethod _).expects(3).returning("three")
+
+      mockWithoutExpectationsPredefined.oneParamMethod(3) === "three"
+    }
+  }
+}

--- a/specs2/specs2-5/jvm/src/test/scala/org/scalamock/test/specs2/SuiteScopePresetMockParallelTest.scala
+++ b/specs2/specs2-5/jvm/src/test/scala/org/scalamock/test/specs2/SuiteScopePresetMockParallelTest.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2011-2015 ScalaMock Contributors (https://github.com/paulbutcher/ScalaMock/graphs/contributors)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package org.scalamock.test.specs2
+
+import org.scalamock.specs2.MockContext
+import org.scalamock.test.mockable.TestTrait
+import org.specs2.mutable.Specification
+
+/**
+ *  Tests for mocks defined with predefined expectations, reused across several test cases.
+ *
+ *  specs2 5.x removed isolated specifications, so a mock defined once in ''suite'' scope
+ *  (outside any example) can no longer have its predefined expectations survive from one
+ *  example into the next - the first example to run would consume/verify them. Reapplying the
+ *  predefined expectations per example via a ''fixture context'' (see [[org.scalamock.specs2.MockContext]])
+ *  gives every example its own fresh mock while still reusing the same expectation setup, and
+ *  keeps examples safe to run in parallel.
+ *
+ *  Tests for issue #25
+ */
+class SuiteScopePresetMockParallelTest extends Specification {
+
+  trait TestSetupWithExpectationsPredefined extends MockContext {
+    val mockWithExpectationsPredefined = mock[TestTrait]
+    (mockWithExpectationsPredefined.oneParamMethod _).expects(0).returning("predefined")
+  }
+
+  "Specs2 suite" should {
+    "allow to use mock defined with predefined expectations" in new TestSetupWithExpectationsPredefined {
+      (mockWithExpectationsPredefined.oneParamMethod _).expects(1).returning("one")
+
+      mockWithExpectationsPredefined.oneParamMethod(0) === "predefined"
+      mockWithExpectationsPredefined.oneParamMethod(1) === "one"
+    }
+
+    "keep predefined mock expectations" in new TestSetupWithExpectationsPredefined {
+      (mockWithExpectationsPredefined.oneParamMethod _).expects(2).returning("two")
+
+      mockWithExpectationsPredefined.oneParamMethod(0) === "predefined"
+      mockWithExpectationsPredefined.oneParamMethod(2) === "two"
+    }
+  }
+}

--- a/specs2/specs2-5/shared/src/main/scala/org/scalamock/specs2/MockContext.scala
+++ b/specs2/specs2-5/shared/src/main/scala/org/scalamock/specs2/MockContext.scala
@@ -1,0 +1,88 @@
+package org.scalamock.specs2
+
+import org.specs2.execute.{AsResult, Scope}
+import org.specs2.specification.Around
+
+/**
+ * Fixture context that should be created per test-case basis
+ *
+ * $techniques
+ *
+ * '''Fixture contexts''' are more flexible and are recommened for complex test suites where single
+ * set of fixtures does not fit all test cases.
+ *
+ * ==Basic usage==
+ *
+ * For simple test cases it's enough to run test case in new `MockContext` scope.
+ *
+ * {{{
+ * class BasicCoffeeMachineTest extends Specification {
+ *
+ *  	"CoffeeMachine" should {
+ *  	     "not turn on the heater when the water container is empty" in new MockContext {
+ *  	         val waterContainerMock = mock[WaterContainer]
+ *  	         (waterContainerMock.isOverfull _).expects().returning(true)
+ *  	         // ...
+ *  	     }
+ *
+ *  	     "not turn on the heater when the water container is overfull" in new MockContext {
+ *  	         val waterContainerMock = mock[WaterContainer]
+ *  	         // ...
+ *  	     }
+ *  	}
+ * }
+ * }}}
+ *
+ * ==Complex fixture contexts==
+ *
+ * When multiple test cases need to work with the same mocks (and more generally - the same
+ * fixtures: files, sockets, database connections, etc.) you can use fixture contexts.
+ *
+ * {{{
+ * class CoffeeMachineTest extends Specification {
+ *
+ * 	trait Test extends MockContext { // fixture context
+ * 	    // shared objects
+ * 	    val waterContainerMock = mock[WaterContainer]
+ * 	    val heaterMock = mock[Heater]
+ * 	    val coffeeMachine = new CoffeeMachine(waterContainerMock, heaterMock)
+ *
+ * 	    // test setup
+ * 	    coffeeMachine.powerOn()
+ * 	}
+ *
+ * 	// you can extend and combine fixture-contexts
+ * 	trait OverfullWaterContainerTest extends Test {
+ * 	    // you can set expectations and use mocks in fixture-context
+ * 	    (waterContainerMock.isEmpty _).expects().returning(true)
+ *
+ * 	    // and define helper functions
+ * 	    def complexLogic() {
+ * 	        coffeeMachine.powerOff()
+ * 	        // ...
+ * 	    }
+ * 	}
+ *
+ * 	"CoffeeMachine" should {
+ * 	     "not turn on the heater when the water container is empty" in new MockContext {
+ * 	         val heaterMock = mock[Heater]
+ * 	         val waterContainerMock = mock[WaterContainer]
+ * 	         val coffeeMachine = new CoffeeMachine(waterContainerMock, heaterMock)
+ * 	         (waterContainerMock.isOverfull _).expects().returning(true)
+ * 	         // ...
+ * 	     }
+ *
+ * 	     "not turn on the heater when the water container is overfull" in new OverfullWaterContainerTest {
+ * 	         // ...
+ * 	         complexLogic()
+ * 	     }
+ * 	}
+ * }
+ * }}}
+ */
+trait MockContext extends MockContextBase with Around with Scope {
+
+  override def around[T: AsResult](body: => T) = {
+    wrapAsResult[T] { body }
+  }
+}

--- a/specs2/specs2-5/shared/src/main/scala/org/scalamock/specs2/MockContextBase.scala
+++ b/specs2/specs2-5/shared/src/main/scala/org/scalamock/specs2/MockContextBase.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2011-2015 ScalaMock Contributors (https://github.com/paulbutcher/ScalaMock/graphs/contributors)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package org.scalamock.specs2
+
+import org.scalamock.MockFactoryBase
+import org.specs2.execute.{AsResult, Failure, FailureException}
+
+/**
+ * Base trait for MockContext and SuiteMockFactory
+ *
+ * @define techniques
+ * To use ScalaMock in Specs2 tests you can either:
+ *  - run each test case in separate '''fixture context''' - [[org.scalamock.specs2.MockContext]] or
+ *  - mix `Specification` with [[org.scalamock.specs2.SuiteMockFactory]] to share mocks defined in
+ *    '''suite scope''' safely across parallel examples
+ */
+trait MockContextBase extends MockFactoryBase {
+
+  type ExpectationException = FailureException
+
+  protected override def newExpectationException(message: String, methodName: Option[Symbol]) =
+    new ExpectationException(Failure(message))
+
+  protected def wrapAsResult[T: AsResult](body: => T) = {
+    AsResult(withExpectations { body })
+  }
+}

--- a/specs2/specs2-5/shared/src/main/scala/org/scalamock/specs2/SuiteMockFactory.scala
+++ b/specs2/specs2-5/shared/src/main/scala/org/scalamock/specs2/SuiteMockFactory.scala
@@ -1,0 +1,56 @@
+package org.scalamock.specs2
+
+import org.specs2.execute.AsResult
+import org.specs2.specification.AroundEach
+
+/**
+ * A trait that can be mixed into a [[http://etorreborre.github.com/specs2/ Specs2]] specification to provide
+ * mocking support for mocks defined in '''suite scope''' (i.e. outside test case scope).
+ *
+ * $techniques
+ *
+ * Specs2 5.x removed "isolated" specifications (each example used to run against its own fresh copy
+ * of the specification instance), so a single specification instance - and therefore a single mock -
+ * is now shared across all of its examples. Since specs2 may run examples of the same specification
+ * concurrently, this trait serializes example execution (via a lock) so that suite-scope mocks can be
+ * safely shared without requiring the whole spec to be marked `sequential`, allowing different
+ * specifications to still run in parallel.
+ *
+ * {{{
+ * class CoffeeMachineTest extends Specification with SuiteMockFactory {
+ *
+ * 	// shared objects
+ * 	val waterContainerMock = mock[WaterContainer]
+ * 	val heaterMock = mock[Heater]
+ * 	val coffeeMachine = new CoffeeMachine(waterContainerMock, heaterMock)
+ *
+ * 	// you can set common expectations in suite scope
+ * 	(waterContainerMock.isOverfull _).expects().returning(true)
+ *
+ * 	// test setup
+ * 	coffeeMachine.powerOn()
+ *
+ * 	"CoffeeMachine" should {
+ * 	    "not turn on the heater when the water container is empty" in {
+ * 	        coffeeMachine.isOn === true
+ * 	        // ...
+ * 	        coffeeMachine.powerOff()
+ * 	        coffeeMachine.isOn === false
+ * 	    }
+ *
+ * 	    "not turn on the heater when the water container is overfull" in {
+ * 	        // examples share a single instance, so expectations set up in suite scope
+ * 	        // must be re-defined/consumed per-example rather than relying on isolation
+ * 	    }
+ * 	}
+ * }
+ * }}}
+ */
+trait SuiteMockFactory extends AroundEach with MockContextBase {
+
+  private val lock = new Object
+
+  override def around[T: AsResult](body: => T) = lock.synchronized {
+    wrapAsResult[T] { body }
+  }
+}

--- a/specs2/specs2-5/shared/src/test/scala/org/scalamock/test/mockable/TestTrait.scala
+++ b/specs2/specs2-5/shared/src/test/scala/org/scalamock/test/mockable/TestTrait.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2011-2015 ScalaMock Contributors (https://github.com/paulbutcher/ScalaMock/graphs/contributors)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package org.scalamock.test.mockable
+
+trait TestTrait {
+  def noParamMethod(): String
+  def oneParamMethod(param: Int): String
+  def polymorphicMethod[T](x: List[T]): String
+}

--- a/specs2/specs2-5/shared/src/test/scala/org/scalamock/test/specs2/BasicTest.scala
+++ b/specs2/specs2-5/shared/src/test/scala/org/scalamock/test/specs2/BasicTest.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2011-2015 ScalaMock Contributors (https://github.com/paulbutcher/ScalaMock/graphs/contributors)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package org.scalamock.test.specs2
+
+import org.scalamock.specs2.MockContext
+import org.scalamock.test.mockable.TestTrait
+import org.specs2.mutable.Specification
+
+/**
+ *  Tests for mocks defined in test case scope
+ *
+ *  Tests for issue #25
+ */
+class BasicTest extends Specification {
+
+  "Specs2 suite" should {
+    "allow to use mock defined in test case scope" in new MockContext {
+      val mockedTrait = mock[TestTrait]
+      (mockedTrait.oneParamMethod _).expects(1).returning("one")
+      (mockedTrait.oneParamMethod _).expects(2).returning("two")
+
+      mockedTrait.oneParamMethod(1) === "one"
+      mockedTrait.oneParamMethod(2) === "two"
+    }
+
+    "use separate call logs for each test case" in new MockContext {
+      val mockedTrait = mock[TestTrait]
+      (mockedTrait.oneParamMethod _).expects(3).returning("three")
+
+      mockedTrait.oneParamMethod(3) === "three"
+    }
+  }
+}

--- a/specs2/specs2-5/shared/src/test/scala/org/scalamock/test/specs2/FixtureContextTest.scala
+++ b/specs2/specs2-5/shared/src/test/scala/org/scalamock/test/specs2/FixtureContextTest.scala
@@ -1,0 +1,70 @@
+// Copyright (c) 2011-2015 ScalaMock Contributors (https://github.com/paulbutcher/ScalaMock/graphs/contributors)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package org.scalamock.test.specs2
+
+import org.scalamock.specs2.MockContext
+import org.scalamock.test.mockable.TestTrait
+import org.specs2.mutable.Specification
+
+/**
+ *  Tests for mocks defined in fixture-contexts
+ *
+ *  Tests for issue #25
+ */
+class FixtureContextTest extends Specification {
+
+  trait TestSetup extends MockContext {
+    val mockedTrait = mock[TestTrait]
+    val input = 1
+    val output = "one"
+  }
+
+  trait TestSetupWithExpectationsPredefined extends TestSetup {
+    (mockedTrait.oneParamMethod _).expects(input).returning(output)
+  }
+
+  trait TestSetupWithHandlerCalledDuringInitialization extends TestSetupWithExpectationsPredefined {
+    mockedTrait.oneParamMethod(input) === output
+  }
+
+  "Specs2 suite" should {
+    "allow to use mock defined in fixture-context" in new TestSetup {
+      (mockedTrait.oneParamMethod _).expects(input).returning(output)
+      (mockedTrait.oneParamMethod _).expects(2).returning("two")
+
+      mockedTrait.oneParamMethod(input) === output
+      mockedTrait.oneParamMethod(2) === "two"
+    }
+
+    "allow to use mock defined in fixture-context with expectations predefined" in new TestSetupWithExpectationsPredefined {
+      (mockedTrait.oneParamMethod _).expects(2).returning("two")
+
+      mockedTrait.oneParamMethod(input) === output
+      mockedTrait.oneParamMethod(2) === "two"
+    }
+
+    "allow mock defined in fixture-context to be used during context initialization" in new TestSetupWithHandlerCalledDuringInitialization {
+      (mockedTrait.oneParamMethod _).expects(2).returning("two")
+
+      mockedTrait.oneParamMethod(2) === "two"
+    }
+  }
+}


### PR DESCRIPTION
Adds a new `specs2-5` cross-project module (JVM/JS/Native), under the same `specs2/` aggregate directory as `specs2-4` (#757), restricted to Scala 3 since specs2 5.x only publishes Scala 3 artifacts.

- `MockContext`/`MockContextBase` ported unchanged (fixture-context style mocking), adapted to extend `org.specs2.execute.Scope` as required by specs2 5.x fixture contexts.
- specs2 5.x removed "isolated" specifications entirely, so `IsolatedMockFactory` has no direct equivalent. Replaced with a new `SuiteMockFactory` trait that wraps `around()` in a lock, keeping suite-scope mocks safe under specs2's default parallel example execution without requiring the whole spec to be `sequential`.
- `SuiteScopePresetMockParallelTest` reworked to use fixture-context style instead of suite-scope, since specs2 5.x no longer duplicates the spec instance per example (so predefined suite-scope expectations can't survive from one example to the next).
- `build.sbt`: new `scalamock-specs2-5` cross-project, aggregated at root.

CI: no workflow changes needed. The `scala_3` job already runs `sbt ++3.9.0 test` against the aggregate root project, which now includes `scalamock-specs2-5`. The `scala_2_12`/`scala_2_13` jobs intentionally exclude it since it's Scala-3-only (same pattern as Scala Native).

Verified locally: `sbt` compile + test for `scalamock-specs2-5JVM` (21 examples, 0 failures), `scalamock-specs2-5JS` (5 examples, 0 failures), and `scalamock-specs2-5Native` (5 examples, 0 failures).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author