### PR TITLE
docs(classic): document using ScalaMock without a test framework

### DIFF
--- a/docs/000_index.md
+++ b/docs/000_index.md
@@ -26,9 +26,9 @@ Supported Platforms
 
 | Scala Version | JVM | JS (1.x) | Native (0.5.x) |
 |---------------|:---:|:--------:|:--------------:|
-| 2.12.x        |  ✅  |    ✅     |  Coming soon   |
-| 2.13.x        |  ✅  |    ✅     |  Coming soon   |
-| 3.x           |  ✅  |    ✅     |  Coming soon   |
+| 2.12.x        |  ✅  |    ✅     |       ❌        |
+| 2.13.x        |  ✅  |    ✅     |       ❌        |
+| 3.x           |  ✅  |    ✅     |       ✅        |
 
 
 ---
@@ -39,12 +39,24 @@ Dependencies
 ![](https://img.shields.io/github/v/release/scalamock/scalamock?color=green])
 {: .d-flex .flex-justify-start }
 
+{: .note }
+> As of **7.6.0**, test framework integrations depend directly on their corresponding test framework instead
+> of pulling it in transitively via the core `scalamock` module. Only add the modules you actually use:
+> `scalamock-scalatest` for ScalaTest, `scalamock-specs2-4` for specs2 4.x, `scalamock-specs2-5` for specs2 5.x
+> (Scala 3 only), `scalamock-zio` for ZIO Test, `scalamock-cats-effect` for cats-effect.
+
 ### sbt
 
 ```scala
 libraryDependencies ++= Seq(
-  // core module
+  // core module - includes stubs
   "org.scalamock" %% "scalamock" % "<version in the badge>" % Test,
+  // scalatest integration
+  "org.scalamock" %% "scalamock-scalatest" % "<version in the badge>" % Test,
+  // specs2 4.x integration
+  "org.scalamock" %% "scalamock-specs2-4" % "<version in the badge>" % Test,
+  // specs2 5.x integration (Scala 3 only)
+  "org.scalamock" %% "scalamock-specs2-5" % "<version in the badge>" % Test,
   // zio integration
   "org.scalamock" %% "scalamock-zio" % "<version in the badge>" % Test,
   // cats-effect integration
@@ -60,6 +72,12 @@ object main extends JavaModule {
     override def ivyDeps =
       Agg(
         ivy"org.scalamock::scalamock:<version in the badge>",
+        // scalatest integration
+        ivy"org.scalamock::scalamock-scalatest:<version in the badge>",
+        // specs2 4.x integration
+        ivy"org.scalamock::scalamock-specs2-4:<version in the badge>",
+        // specs2 5.x integration (Scala 3 only)
+        ivy"org.scalamock::scalamock-specs2-5:<version in the badge>",
         // zio integration
         ivy"org.scalamock::scalamock-zio:<version in the badge>",
         // cats-effect integration
@@ -73,6 +91,9 @@ object main extends JavaModule {
 
 ```scala
 //> using test.dep "org.scalamock::scalamock:<version in the badge>"
+//> using test.dep "org.scalamock::scalamock-scalatest:<version in the badge>"
+//> using test.dep "org.scalamock::scalamock-specs2-4:<version in the badge>"
+//> using test.dep "org.scalamock::scalamock-specs2-5:<version in the badge>"
 //> using test.dep "org.scalamock::scalamock-zio:<version in the badge>"
 //> using test.dep "org.scalamock::scalamock-cats-effect:<version in the badge>"
 ```
@@ -81,10 +102,31 @@ object main extends JavaModule {
 
 ```xml
 <dependencies>
-  <!-- core module -->
+  <!-- core module - includes stubs -->
   <dependency>
     <groupId>org.scalamock</groupId>
     <artifactId>scalamock_3</artifactId>
+    <version><!-- version in the badge --></version>
+    <scope>test</scope>
+  </dependency>
+  <!-- scalatest integration -->
+  <dependency>
+    <groupId>org.scalamock</groupId>
+    <artifactId>scalamock-scalatest_3</artifactId>
+    <version><!-- version in the badge --></version>
+    <scope>test</scope>
+  </dependency>
+  <!-- specs2 4.x integration -->
+  <dependency>
+    <groupId>org.scalamock</groupId>
+    <artifactId>scalamock-specs2-4_3</artifactId>
+    <version><!-- version in the badge --></version>
+    <scope>test</scope>
+  </dependency>
+  <!-- specs2 5.x integration (Scala 3 only) -->
+  <dependency>
+    <groupId>org.scalamock</groupId>
+    <artifactId>scalamock-specs2-5_3</artifactId>
     <version><!-- version in the badge --></version>
     <scope>test</scope>
   </dependency>
@@ -114,7 +156,7 @@ Getting started
 ### Classic + scalatest
 
 ```scala
-//> using test.dep org.scalamock::scalamock:7.3.2
+//> using test.dep org.scalamock::scalamock-scalatest:7.6.0
 //> using test.dep org.scalatest::scalatest:3.2.19
 
 import org.scalamock.scalatest.MockFactory
@@ -141,7 +183,7 @@ class MyTest extends AnyFlatSpec, MockFactory:
 ### Classic + specs2
 
 ```scala
-//> using test.dep org.scalamock::scalamock:7.3.2
+//> using test.dep org.scalamock::scalamock-specs2-5:7.6.0
 //> using test.dep org.specs2::specs2-core:5.6.3
 
 import org.scalamock.specs2.MockContext
@@ -175,7 +217,7 @@ class MySpec extends Specification {
 ```scala
 //> using dep dev.zio::zio:2.1.19
 //> using test.dep dev.zio::zio-test:2.1.19
-//> using test.dep org.scalamock::scalamock-zio:7.5.0
+//> using test.dep org.scalamock::scalamock-zio:7.6.0
 
 import org.scalamock.ziotest._
 import zio._
@@ -204,7 +246,7 @@ object UserServiceTest extends ScalamockZIOSpec {
 ### Stubs + munit
 
 ```scala
-//> using test.dep org.scalamock::scalamock:7.3.2
+//> using test.dep org.scalamock::scalamock:7.6.0
 //> using test.dep org.scalameta::munit:1.1.1
 
 import org.scalamock.stubs.Stubs
@@ -233,7 +275,7 @@ class MyTest extends FunSuite, Stubs:
 ### Stubs + scalatest
 
 ```scala
-//> using test.dep org.scalamock::scalamock:7.3.2
+//> using test.dep org.scalamock::scalamock:7.6.0
 //> using test.dep org.scalatest::scalatest:3.2.19
 
 import org.scalamock.stubs.Stubs
@@ -262,7 +304,7 @@ class MyTest extends AnyFunSuite, Matchers, Stubs:
 ### Stubs + specs2
 
 ```scala
-//> using test.dep org.scalamock::scalamock:7.3.2
+//> using test.dep org.scalamock::scalamock-specs2-5:7.6.0
 //> using test.dep org.specs2::specs2-core:5.6.3
 
 import org.scalamock.stubs.Stubs
@@ -293,9 +335,9 @@ class MySpec extends Specification, Stubs:
 ### Stubs + ZIO test
 
 ```scala
-//> using dep dev.zio::zio:2.1.17
-//> using test.dep dev.zio::zio-test:2.1.17
-//> using test.dep org.scalamock::scalamock-zio:7.3.2
+//> using dep dev.zio::zio:2.1.19
+//> using test.dep dev.zio::zio-test:2.1.19
+//> using test.dep org.scalamock::scalamock-zio:7.6.0
 
 import org.scalamock.stubs.ZIOStubs
 import zio.test.*
@@ -333,7 +375,7 @@ class MyTest extends ZIOSpecDefault, ZIOStubs:
 
 ```scala
 //> using dep org.typelevel::cats-effect:3.6.1
-//> using test.dep org.scalamock::scalamock-cats-effect:7.3.2
+//> using test.dep org.scalamock::scalamock-cats-effect:7.6.0
 //> using test.dep org.typelevel::munit-cats-effect:2.1.0
 
 import org.scalamock.stubs.CatsEffectStubs

--- a/docs/classic/000_index.md
+++ b/docs/classic/000_index.md
@@ -74,11 +74,17 @@ class ExchangeRateListingTest extends AsyncFlatSpec with AsyncMockFactory {
 }
 ```
 ### Specs2
-To use **scalamock** with **specs2** you should run each test case in a separate fixture context that mixins `org.scalamock.specs2.MockContext`
+
+Specs2 integration is split into two modules, depending on which major version of specs2 you use:
+
+- `scalamock-specs2-4` - for specs2 4.x, available for Scala 2.13 and Scala 3
+- `scalamock-specs2-5` - for specs2 5.x, available for Scala 3 only (specs2 5.x dropped Scala 2 support entirely)
+
+Both modules provide the same `org.scalamock.specs2.MockContext` fixture-context trait. To use **scalamock** with **specs2** you should run each test case in a separate fixture context that mixins `org.scalamock.specs2.MockContext`
 
 ```scala
-//> using test.dep org.scalamock::scalamock:7.4.1
-//> using test.dep org.specs2::specs2-core:5.6.3
+//> using test.dep org.scalamock::scalamock-specs2-4:7.5.0
+//> using test.dep org.specs2::specs2-core:4.23.0
 
 import org.scalamock.specs2.MockContext
 import org.specs2.mutable.Specification
@@ -90,7 +96,7 @@ class MySpec extends Specification {
     val service2 = stub[Service2]
     val service3 = Service3(service1, service2)
   }
-  
+
   "CoffeeMachine" should {
     "not turn on the heater when the water container is empty" in new Wiring {
       val waterContainerMock = mock[WaterContainer]
@@ -99,6 +105,20 @@ class MySpec extends Specification {
   }
 }
 ```
+
+To use it with specs2 5.x instead, swap the dependency for `scalamock-specs2-5` (Scala 3 only):
+
+```scala
+//> using test.dep org.scalamock::scalamock-specs2-5:7.5.0
+//> using test.dep org.specs2::specs2-core:5.9.1
+```
+
+{: .note }
+> Specs2 5.x removed "isolated" specifications, so a single specification instance (and any mocks defined
+> in its suite scope, outside a fixture context) is now shared across all of its examples. If you need
+> **suite-scope** mocks with specs2 5.x, mixin `org.scalamock.specs2.SuiteMockFactory` instead of/alongside
+> `MockContext` - it serializes example execution for that specification via a lock so suite-scope mocks
+> stay safe even when specs2 schedules examples of different specifications in parallel.
 
 ### ZIO Test
 

--- a/docs/classic/000_index.md
+++ b/docs/classic/000_index.md
@@ -146,3 +146,9 @@ object ApiServiceSpec extends ScalamockZIOSpec {
 }
 
 ```
+
+### Other frameworks
+
+Not using ScalaTest, Specs2 or ZIO Test? You can still use **scalamock** by implementing your own subtype of `org.scalamock.MockFactoryBase`. This makes it possible to adapt ScalaMock to any testing framework (JUnit, MUnit, uTest, etc.), or use it without a framework at all.
+
+For a detailed guide, see [Other Frameworks](/classic/other-frameworks/).

--- a/docs/classic/000_index.md
+++ b/docs/classic/000_index.md
@@ -24,17 +24,17 @@ The first rule of **scalamock** is not to share any mocks and stubs between your
 Usually - you should create some fixture/wiring to be reused in each test-case.
 
 {: .note }
-> As of **7.6.0**, test framework integrations are being extracted out of the core `scalamock` artifact into
-> their own published modules with their own dependency on the corresponding framework - see the
-> [Specs2](#specs2) section below. **Scalatest** integration is still bundled in the core `scalamock` module
-> for now, but will be extracted into its own `scalamock-scalatest` module the same way in an upcoming release.
+> As of **7.6.0**, test framework integrations are extracted out of the core `scalamock` artifact into their
+> own published modules with their own dependency on the corresponding framework: `scalamock-scalatest` for
+> Scalatest, `scalamock-specs2-4`/`scalamock-specs2-5` for specs2 (see the [Specs2](#specs2) section below),
+> and `scalamock-zio` for ZIO Test.
 
 ### Scalatest
 
 To use **scalamock** with **scalatest** - your suite should mixin `org.scalamock.scalatest.MockFactory`
 
 ```scala
-//> using test.dep org.scalamock::scalamock:7.4.1
+//> using test.dep org.scalamock::scalamock-scalatest:7.6.0
 //> using test.dep org.scalatest::scalatest:3.2.19
 
 import org.scalamock.scalatest.MockFactory
@@ -134,7 +134,7 @@ For detailed ZIO Test integration guide, see [ZIO Test Integration](/classic/zio
 
 ```scala
 //> using dep dev.zio::zio:2.1.19
-//> using test.dep org.scalamock::scalamock-zio:7.5.0
+//> using test.dep org.scalamock::scalamock-zio:7.6.0
 //> using test.dep dev.zio::zio-test:2.1.19
 
 import org.scalamock.ziotest._

--- a/docs/classic/000_index.md
+++ b/docs/classic/000_index.md
@@ -23,6 +23,12 @@ The first rule of **scalamock** is not to share any mocks and stubs between your
 
 Usually - you should create some fixture/wiring to be reused in each test-case.
 
+{: .note }
+> As of **7.6.0**, test framework integrations are being extracted out of the core `scalamock` artifact into
+> their own published modules with their own dependency on the corresponding framework - see the
+> [Specs2](#specs2) section below. **Scalatest** integration is still bundled in the core `scalamock` module
+> for now, but will be extracted into its own `scalamock-scalatest` module the same way in an upcoming release.
+
 ### Scalatest
 
 To use **scalamock** with **scalatest** - your suite should mixin `org.scalamock.scalatest.MockFactory`
@@ -83,7 +89,7 @@ Specs2 integration is split into two modules, depending on which major version o
 Both modules provide the same `org.scalamock.specs2.MockContext` fixture-context trait. To use **scalamock** with **specs2** you should run each test case in a separate fixture context that mixins `org.scalamock.specs2.MockContext`
 
 ```scala
-//> using test.dep org.scalamock::scalamock-specs2-4:7.5.0
+//> using test.dep org.scalamock::scalamock-specs2-4:7.6.0
 //> using test.dep org.specs2::specs2-core:4.23.0
 
 import org.scalamock.specs2.MockContext
@@ -109,7 +115,7 @@ class MySpec extends Specification {
 To use it with specs2 5.x instead, swap the dependency for `scalamock-specs2-5` (Scala 3 only):
 
 ```scala
-//> using test.dep org.scalamock::scalamock-specs2-5:7.5.0
+//> using test.dep org.scalamock::scalamock-specs2-5:7.6.0
 //> using test.dep org.specs2::specs2-core:5.9.1
 ```
 

--- a/docs/classic/other-frameworks.md
+++ b/docs/classic/other-frameworks.md
@@ -1,0 +1,70 @@
+---
+layout: default
+title: Other Frameworks
+parent: Classic
+nav_order: 3
+permalink: /classic/other-frameworks/
+---
+
+# Using ScalaMock without ScalaTest, Specs2 or ZIO Test
+
+You don't need ScalaTest, Specs2 or ZIO Test to use **scalamock**. All the integrations above are just thin
+adapters around `org.scalamock.MockFactoryBase`, so you can implement your own subtype of it and adapt
+**scalamock** to any other testing framework (JUnit, MUnit, uTest, etc.), or use it without a framework at all.
+
+To do that you need to:
+
+1. Extend `org.scalamock.MockFactoryBase` (this also brings `mock[T]`/`stub[T]` into scope).
+2. Provide the `ExpectationException` type member and `newExpectationException` - the exception thrown when
+   an expectation is not met.
+3. Wrap each test case body with `withExpectations { ... }` - it resets call logs/expectations before the
+   test case and verifies them once the body completes.
+
+```scala
+//> using dep org.scalamock::scalamock:7.5.0
+
+import org.scalamock.MockFactoryBase
+
+trait Cat {
+  def meow(): Unit
+  def isHungry: Boolean
+}
+
+class MyMockFactory extends MockFactoryBase {
+  type ExpectationException = Exception
+
+  override protected def newExpectationException(message: String, methodName: Option[Symbol]): Exception =
+    new Exception(s"$message, $methodName")
+
+  // expose withExpectations under a more descriptive name for test cases to use
+  def test[T](body: => T): T = withExpectations(body)
+}
+
+@main def run(): Unit =
+  given mc: MyMockFactory = new MyMockFactory
+
+  mc.test {
+    // and am mocking a cat
+    val cat = mc.mock[Cat]
+    // and the cat meows
+    cat.meow.expects().returns(())
+    // and the cat is always hungry
+    cat.isHungry.expects().returns(true).anyNumberOfTimes()
+
+    // then the cat needs feeding
+    assert(cat.isHungry)
+
+    cat.meow()
+    // withExpectations verifies here that cat.meow() was called exactly once
+  }
+```
+
+{: .note }
+> Each test case should use its own `MyMockFactory` instance (or run inside its own `withExpectations` block),
+> otherwise mocks and expectations may leak between test cases, similarly to sharing mocks between ScalaTest
+> or Specs2 test cases.
+
+If your framework runs test cases as ordinary methods/functions, a common pattern is to create a fresh
+`MockFactoryBase` instance per test case, e.g. in a `setUp`/fixture method, and call `withExpectations` around
+the test body, the same way `org.scalamock.scalatest.MockFactory` wraps ScalaTest's `withFixture` or
+`org.scalamock.specs2.MockContext` wraps a Specs2 fixture context.


### PR DESCRIPTION
Adds an 'Other frameworks' subsection to the classic integrations index page and a dedicated guide showing how to subclass org.scalamock.MockFactoryBase directly, without ScalaTest, Specs2 or ZIO Test. Closes #690.

# Pull Request Checklist

* [ ] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [ ] I have added copyright headers to new files
* [ ] I have added tests for any changed functionality

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
