### PR TITLE
Refactor Scala 3 mock/stub macros to share anonymous class scaffolding

### DIFF
--- a/core/shared/src/main/scala-3/org/scalamock/clazz/MakerUtils.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/MakerUtils.scala
@@ -72,6 +72,58 @@ class MakerUtils(using override val quotes: Quotes) extends Utils:
   end parentsOf
 
   /**
+   *  Builds `class $anonName extends ...T { ... }` and instantiates it.
+   *  This is the Scala 3 equivalent of the shared `Utils.instance` helper used by Scala 2 macros
+   *  to reuse code between classic mocks and stubs: it takes care of extending T (via [[parentsOf]])
+   *  and wiring up the anonymous class/instantiation boilerplate, while the caller only supplies
+   *  the members that differ between mocks and stubs.
+   *
+   * @param anonName    name of the generated anonymous class
+   * @param extraDecls  extra symbols to declare on the class, not tied to any particular mocked method
+   *                    (e.g. a field holding the mock's default name, or stub bookkeeping members)
+   * @param extraBody   definitions matching `extraDecls`
+   * @param methodDecls symbols to declare for a single mocked method (e.g. a backing field plus its override)
+   * @param methodBody  definitions matching `methodDecls` for a single mocked method
+   * @return an instance of the anonymous class, typed as `T & scala.reflect.Selectable`
+   */
+  def buildInstance[T: Type](
+    anonName: String,
+    extraDecls: (Symbol, List[MockableDefinition]) => List[Symbol],
+    extraBody: (Symbol, List[MockableDefinition]) => List[Statement],
+    methodDecls: (Symbol, MockableDefinition) => List[Symbol],
+    methodBody: (Symbol, MockableDefinition) => List[Statement]
+  ): Term =
+    val tpe = TypeRepr.of[T]
+    val parents = parentsOf[T]
+    val methods = MockableDefinitions(tpe)
+
+    val classSymbol: Symbol = Symbol.newClass(
+      owner = Symbol.spliceOwner,
+      name = anonName,
+      parents = parents.map {
+        case term: Term => term.tpe
+        case tree: TypeTree => tree.tpe
+      },
+      decls = classSymbol => extraDecls(classSymbol, methods) ::: methods.flatMap(methodDecls(classSymbol, _)),
+      selfType = None
+    )
+
+    val classDef = ClassDef(
+      cls = classSymbol,
+      parents = parents,
+      body = extraBody(classSymbol, methods) ::: methods.flatMap(methodBody(classSymbol, _))
+    )
+
+    Block(
+      List(classDef),
+      Typed(
+        Apply(Select(New(TypeIdent(classSymbol)), classSymbol.primaryConstructor), Nil),
+        TypeTree.of[T & scala.reflect.Selectable]
+      )
+    )
+  end buildInstance
+
+  /**
    *  Loops through inlined method call to find mocked object and called method name.
    *  Searches method info (MockableDefinition) through all relevant methods collected from TypeRepr.
    * 

--- a/core/shared/src/main/scala-3/org/scalamock/clazz/MockMaker.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/MockMaker.scala
@@ -32,19 +32,27 @@ private[clazz] object MockMaker:
     val utils = MakerUtils(using quotes)
     import utils.quotes.reflect.*
     val tpe = TypeRepr.of[T]
-    val mockableDefinitions = utils.MockableDefinitions(tpe)
-    val parents = utils.parentsOf[T]
+
     def createDefaultMockNameSymbol(classSymbol: Symbol) =
       Symbol.newVal(classSymbol, MockDefaultNameValName, TypeRepr.of[String], Flags.EmptyFlags, Symbol.noSymbol)
 
-    val classSymbol: Symbol = Symbol.newClass(
-      owner = Symbol.spliceOwner,
-      name = "$anon",
-      parents = parents.map {
-        case term: Term => term.tpe
-        case tree: TypeTree => tree.tpe
-      },
-      decls = classSymbol => createDefaultMockNameSymbol(classSymbol) :: mockableDefinitions.flatMap { definition =>
+    val instance = utils.buildInstance[T](
+      anonName = "$anon",
+      extraDecls = (classSymbol, _) => List(createDefaultMockNameSymbol(classSymbol)),
+      extraBody = (classSymbol, _) =>
+        val defaultMockNameSymbol = classSymbol.declaredField(MockDefaultNameValName)
+        List(
+          ValDef(
+            defaultMockNameSymbol,
+            Some(
+              name
+                .getOrElse('{ ${ctx}.generateMockDefaultName(${ Expr(mockType.toString.toLowerCase) }).name })
+                .asTerm
+            )
+          )
+        )
+      ,
+      methodDecls = (classSymbol, definition) =>
         val mockFunctionClassSym =
           Symbol.classSymbol(s"org.scalamock.function.${mockType}Function${definition.rawTypes.length}")
 
@@ -77,88 +85,69 @@ private[clazz] object MockMaker:
             )
 
         List(mockFunctionSym, overrideSym)
-      },
-      selfType = None
-    )
-    val defaultMockNameSymbol = classSymbol.declaredField(MockDefaultNameValName)
+      ,
+      methodBody = (classSymbol, definition) =>
+        val defaultMockNameSymbol = classSymbol.declaredField(MockDefaultNameValName)
 
-    val defaultMockName = ValDef(
-      defaultMockNameSymbol,
-      Some(
-        name
-          .getOrElse('{ ${ctx}.generateMockDefaultName(${ Expr(mockType.toString.toLowerCase) }).name })
-          .asTerm
-      )
-    )
-
-    val classDef: ClassDef =
-      ClassDef(
-        cls = classSymbol,
-        parents = parents,
-        body = defaultMockName :: mockableDefinitions.flatMap { definition =>
-          val mockFunctionValDef: ValDef =
-            val valSym = classSymbol.declaredField(definition.mockValName)
-            val mockFunctionClassSymbol = valSym.typeRef.classSymbol.get
-            val mockFunctionUniqueName = '{
-              scala.Symbol(
-                Predef.augmentString("<%s> %s%s.%s%s")
-                  .format(
-                    ${ Ref(defaultMockNameSymbol).asExpr },
-                    ${ Expr(tpe.typeSymbol.name) },
-                    ${ Expr(if (tpe.typeArgs.isEmpty) "" else "[%s]".format(tpe.typeArgs.map(_.show(using Printer.TypeReprShortCode)).mkString(","))) },
-                    ${ Expr(definition.symbol.name) },
-                    ${ Expr {
-                      definition.tpe match
-                        case PolyType(params, _, _) => params.mkString("[", ",", "]")
-                        case _ => ""
-                    }
-                    }
-                  )
-              )
-            }
-            ValDef(
-              symbol = valSym,
-              rhs = Some(
-                Apply(
-                  TypeApply(
-                    Select(
-                      New(TypeIdent(mockFunctionClassSymbol)),
-                      mockFunctionClassSymbol.primaryConstructor
-                    ),
-                    List.fill(definition.rawTypes.length + 1)(TypeTree.of[Any])
-                  ),
-                  List(ctx.asTerm, mockFunctionUniqueName.asTerm)
+        val mockFunctionValDef: ValDef =
+          val valSym = classSymbol.declaredField(definition.mockValName)
+          val mockFunctionClassSymbol = valSym.typeRef.classSymbol.get
+          val mockFunctionUniqueName = '{
+            scala.Symbol(
+              Predef.augmentString("<%s> %s%s.%s%s")
+                .format(
+                  ${ Ref(defaultMockNameSymbol).asExpr },
+                  ${ Expr(tpe.typeSymbol.name) },
+                  ${ Expr(if (tpe.typeArgs.isEmpty) "" else "[%s]".format(tpe.typeArgs.map(_.show(using Printer.TypeReprShortCode)).mkString(","))) },
+                  ${ Expr(definition.symbol.name) },
+                  ${ Expr {
+                    definition.tpe match
+                      case PolyType(params, _, _) => params.mkString("[", ",", "]")
+                      case _ => ""
+                  }
+                  }
                 )
+            )
+          }
+          ValDef(
+            symbol = valSym,
+            rhs = Some(
+              Apply(
+                TypeApply(
+                  Select(
+                    New(TypeIdent(mockFunctionClassSymbol)),
+                    mockFunctionClassSymbol.primaryConstructor
+                  ),
+                  List.fill(definition.rawTypes.length + 1)(TypeTree.of[Any])
+                ),
+                List(ctx.asTerm, mockFunctionUniqueName.asTerm)
               )
             )
+          )
 
-          val definitionOverride =
-            if (definition.symbol.isValDef)
-              ValDef(definition.symbol.overridingSymbol(classSymbol), Some('{ null }.asTerm))
-            else
-              DefDef(
-                definition.symbol.overridingSymbol(classSymbol),
-                { args =>
-                  Some(
-                    TypeApply(
-                      Select.unique(
-                        Apply(
-                          Select.unique(Ref(mockFunctionValDef.symbol), "apply"),
-                          args.flatten.collect { case t: Term => t }
-                        ),
-                        "asInstanceOf"
+        val definitionOverride =
+          if (definition.symbol.isValDef)
+            ValDef(definition.symbol.overridingSymbol(classSymbol), Some('{ null }.asTerm))
+          else
+            DefDef(
+              definition.symbol.overridingSymbol(classSymbol),
+              { args =>
+                Some(
+                  TypeApply(
+                    Select.unique(
+                      Apply(
+                        Select.unique(Ref(mockFunctionValDef.symbol), "apply"),
+                        args.flatten.collect { case t: Term => t }
                       ),
-                      definition.prepareResType(classSymbol, args)
-                        .asType match { case '[t] => List(TypeTree.of[t]) }
-                    )
+                      "asInstanceOf"
+                    ),
+                    definition.prepareResType(classSymbol, args)
+                      .asType match { case '[t] => List(TypeTree.of[t]) }
                   )
-                }
-              )
-          List(mockFunctionValDef, definitionOverride)
-        }
-      )
+                )
+              }
+            )
+        List(mockFunctionValDef, definitionOverride)
+    )
 
-    Block(
-      List(classDef),
-      Typed(Apply(Select(New(TypeIdent(classSymbol)), classSymbol.primaryConstructor), Nil), TypeTree.of[T & Selectable])
-    ).asExprOf[T & Selectable]
+    instance.asExprOf[T & Selectable]

--- a/core/shared/src/main/scala-3/org/scalamock/stubs/internal/StubMaker.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/stubs/internal/StubMaker.scala
@@ -39,78 +39,29 @@ private[stubs] class StubMaker(
     collector: Expr[CreatedStubs],
     stubUniqueIndexGenerator: Expr[StubUniqueIndexGenerator]
   ): Expr[Stub[T]] =
-    val tpe = TypeRepr.of[T]
-    val parents = parentsOf[T]
-    val methods = MockableDefinitions(tpe)
-    val log = Expr.summon[CallLog]
-
-    val classSymbol = Symbol.newClass(
-      owner = Symbol.spliceOwner,
-      name = "anon",
-      parents = parents.map {
-        case term: Term => term.tpe
-        case tpt: TypeTree => tpt.tpe
-      },
-      decls = classSymbol =>
-        methods.flatMap { method =>
-          List(
-            // Creates a field to store stubbed method representation
-            // val stub$<name>$<idx>: StubbedMethod.Internal[Any, Any]
-            Symbol.newVal(
-              parent = classSymbol,
-              name = method.stubValName,
-              tpe = TypeRepr.of[StubbedMethod.Internal[Any, Any]],
-              flags = Flags.EmptyFlags,
-              privateWithin = Symbol.noSymbol
-            ),
-            // Creates an override for the val
-            // override val <name>: type
-            if method.symbol.isValDef then
-              Symbol.newVal(
-                parent = classSymbol,
-                name = method.symbol.name,
-                tpe = This(classSymbol).tpe.memberType(method.symbol),
-                flags = Flags.Override,
-                privateWithin = Symbol.noSymbol
-              )
-            else
-              // Creates an implementation for the method, which will use StubbedMethod.Internal under the hood
-              // override def <name>(...args): type
-              Symbol.newMethod(
-                parent = classSymbol,
-                name = method.symbol.name,
-                tpe = This(classSymbol).tpe.memberType(method.symbol),
-                flags = Flags.Override,
-                privateWithin = Symbol.noSymbol
-              ),
-          )
-        } ::: List(
-          // Creates a method to clear this stub
-          // def stub$macro$clear(): Unit
-          Symbol.newMethod(
-            parent = classSymbol,
-            name = ClearStubsMethodName,
-            tpe = MethodType(Nil)(_ => Nil, _ => TypeRepr.of[Unit]),
-            flags = Flags.EmptyFlags,
-            privateWithin = Symbol.noSymbol
-          ),
-          // Creates a field to store unique index for this stub
-          // val stub$macro$idx: Int
-          Symbol.newVal(
-            parent = classSymbol,
-            name = UniqueStubIdx,
-            tpe = TypeRepr.of[Int],
-            flags = Flags.EmptyFlags,
-            privateWithin = Symbol.noSymbol
-          )
+    val instance = buildInstance[T](
+      anonName = "anon",
+      extraDecls = (classSymbol, _) => List(
+        // Creates a method to clear this stub
+        // def stub$macro$clear(): Unit
+        Symbol.newMethod(
+          parent = classSymbol,
+          name = ClearStubsMethodName,
+          tpe = MethodType(Nil)(_ => Nil, _ => TypeRepr.of[Unit]),
+          flags = Flags.EmptyFlags,
+          privateWithin = Symbol.noSymbol
         ),
-      selfType = None
-    )
-
-    val classDef = ClassDef(
-      cls = classSymbol,
-      parents = parents,
-      body = List(
+        // Creates a field to store unique index for this stub
+        // val stub$macro$idx: Int
+        Symbol.newVal(
+          parent = classSymbol,
+          name = UniqueStubIdx,
+          tpe = TypeRepr.of[Int],
+          flags = Flags.EmptyFlags,
+          privateWithin = Symbol.noSymbol
+        )
+      ),
+      extraBody = (classSymbol, methods) => List(
         // Creates a method to clear this stub
         // val stub$<name>$<idx>
         // def stub$macro$clear(): Unit = stub$<name>$<idx>.clear()
@@ -128,55 +79,74 @@ private[stubs] class StubMaker(
           symbol = classSymbol.declaredField(UniqueStubIdx),
           Some('{ $stubUniqueIndexGenerator.nextIdx() }.asTerm)
         )
-      ) ::: methods.flatMap { method =>
-        List(
-          ValDef(
-            classSymbol.declaredField(method.stubValName),
-            Some {
-              val callLog = Expr.summon[CallLog] match {
-                case Some(log) => '{ Some(${log}) }
-                case None => '{ None }
-              }
-              val idx = Ref(classSymbol.declaredField(UniqueStubIdx)).asExprOf[Int]
-              val ioOpt = Expr.summon[StubIO].filter(_.isMatches(method.rawResType)) match
-                case Some(io) => '{ Some($io) }
-                case None => '{None}
-
-              '{
-                new StubbedMethod.Internal[Any, Any](
-                  s"<stub-" + $idx + "> " + ${ Expr(method.show) },
-                  $callLog,
-                  $ioOpt
-                )
-              }.asTerm
-            }
-          ),
-          if (method.symbol.isValDef)
-            ValDef(method.symbol.overridingSymbol(classSymbol), Some('{ null }.asTerm))
-          else
-            DefDef(
-              symbol = method.symbol.overridingSymbol(classSymbol),
-              params => Some {
-                method.prepareResType(classSymbol, params).asType match
-                  case '[res] =>
-                    val tupledArgs = tupled(params.flatMap {_.collect { case term: Term => term }}).asExpr
-                    '{ ${ method.stubbedMethodRef(classSymbol) }.impl(${tupledArgs}).asInstanceOf[res] }
-                      .asTerm
-                      .changeOwner(method.symbol.overridingSymbol(classSymbol))
-              }
-            )
-        )
-      }
-    )
-
-    val instance = Block(
-      List(classDef),
-      Typed(
-        Apply(
-          Select(New(TypeIdent(classSymbol)), classSymbol.primaryConstructor),
-          Nil
+      ),
+      methodDecls = (classSymbol, method) => List(
+        // Creates a field to store stubbed method representation
+        // val stub$<name>$<idx>: StubbedMethod.Internal[Any, Any]
+        Symbol.newVal(
+          parent = classSymbol,
+          name = method.stubValName,
+          tpe = TypeRepr.of[StubbedMethod.Internal[Any, Any]],
+          flags = Flags.EmptyFlags,
+          privateWithin = Symbol.noSymbol
         ),
-        TypeTree.of[T & scala.reflect.Selectable]
+        // Creates an override for the val
+        // override val <name>: type
+        if method.symbol.isValDef then
+          Symbol.newVal(
+            parent = classSymbol,
+            name = method.symbol.name,
+            tpe = This(classSymbol).tpe.memberType(method.symbol),
+            flags = Flags.Override,
+            privateWithin = Symbol.noSymbol
+          )
+        else
+          // Creates an implementation for the method, which will use StubbedMethod.Internal under the hood
+          // override def <name>(...args): type
+          Symbol.newMethod(
+            parent = classSymbol,
+            name = method.symbol.name,
+            tpe = This(classSymbol).tpe.memberType(method.symbol),
+            flags = Flags.Override,
+            privateWithin = Symbol.noSymbol
+          ),
+      ),
+      methodBody = (classSymbol, method) => List(
+        ValDef(
+          classSymbol.declaredField(method.stubValName),
+          Some {
+            val callLog = Expr.summon[CallLog] match {
+              case Some(log) => '{ Some(${log}) }
+              case None => '{ None }
+            }
+            val idx = Ref(classSymbol.declaredField(UniqueStubIdx)).asExprOf[Int]
+            val ioOpt = Expr.summon[StubIO].filter(_.isMatches(method.rawResType)) match
+              case Some(io) => '{ Some($io) }
+              case None => '{None}
+
+            '{
+              new StubbedMethod.Internal[Any, Any](
+                s"<stub-" + $idx + "> " + ${ Expr(method.show) },
+                $callLog,
+                $ioOpt
+              )
+            }.asTerm
+          }
+        ),
+        if (method.symbol.isValDef)
+          ValDef(method.symbol.overridingSymbol(classSymbol), Some('{ null }.asTerm))
+        else
+          DefDef(
+            symbol = method.symbol.overridingSymbol(classSymbol),
+            params => Some {
+              method.prepareResType(classSymbol, params).asType match
+                case '[res] =>
+                  val tupledArgs = tupled(params.flatMap {_.collect { case term: Term => term }}).asExpr
+                  '{ ${ method.stubbedMethodRef(classSymbol) }.impl(${tupledArgs}).asInstanceOf[res] }
+                    .asTerm
+                    .changeOwner(method.symbol.overridingSymbol(classSymbol))
+            }
+          )
       )
     )
     //println(instance.show)


### PR DESCRIPTION
MockMaker.instance and StubMaker.newInstance now delegate the Symbol.newClass/ClassDef/Block boilerplate to MakerUtils.buildInstance, mirroring how the Scala 2 macros share this logic via Utils.instance. Each maker only supplies the extra/per-method declarations and bodies that differ between mocks and stubs.
